### PR TITLE
Fix warning when using key parameter of kmip_bio_register_symmetric_key

### DIFF
--- a/kmippp/kmippp.cpp
+++ b/kmippp/kmippp.cpp
@@ -160,7 +160,7 @@ context::id_t context::op_register(context::name_t name, name_t group, key_t key
 
     int id_max_len = 64;
     char* idp = nullptr;
-    int result = kmip_bio_register_symmetric_key(bio_, &ta, reinterpret_cast<char*>(key.data()), key.size(), &idp, &id_max_len);
+    int result = kmip_bio_register_symmetric_key(bio_, &ta, key.data(), key.size(), &idp, &id_max_len);
     
     std::string ret;
     if(idp != nullptr) {

--- a/kmippp/kmippp.h
+++ b/kmippp/kmippp.h
@@ -16,7 +16,7 @@ namespace kmippp {
   class context {
     public:
 
-      using key_t = std::vector<unsigned char>;
+      using key_t = std::vector<uint8_t>;
       using id_t = std::string;
       using ids_t = std::vector<std::string>;
       using name_t = std::string;

--- a/libkmip/include/kmip_bio.h
+++ b/libkmip/include/kmip_bio.h
@@ -39,7 +39,7 @@ OpenSSH BIO API
 */
 
 int kmip_bio_create_symmetric_key(BIO *, TemplateAttribute *, char **, int *);
-int kmip_bio_register_symmetric_key(BIO *, TemplateAttribute *, char*, int, char **, int *);
+int kmip_bio_register_symmetric_key(BIO *, TemplateAttribute *, uint8_t*, int, char **, int *);
 int kmip_bio_get_symmetric_key(BIO *, char *, int, char **, int *);
 int kmip_bio_get_name_attribute(BIO *, char *, int, char **, int *);
 int kmip_bio_destroy_symmetric_key(BIO *, char *, int);

--- a/libkmip/src/kmip_bio.c
+++ b/libkmip/src/kmip_bio.c
@@ -264,7 +264,7 @@ int kmip_bio_create_symmetric_key(BIO *bio,
 
 int kmip_bio_register_symmetric_key(BIO *bio,
                                     TemplateAttribute *template_attribute,
-                                    char* key, int key_len,
+                                    uint8* key, int key_len,
                                     char **id, int *id_size)
 {
     if(bio == NULL || template_attribute == NULL || id == NULL || id_size == NULL || key == NULL || key_len == 0)


### PR DESCRIPTION
*Problem*:

clang 10 shows the following warning:

```
/libkmip/libkmip/src/kmip_bio.c:313:14:
warning: assigning to 'uint8 *' (aka 'unsigned char *') from 'char *'
converts between pointers to integer types with different sign
[-Wpointer-sign]
    bs.value = key;
             ^ ~~~
```

*Solution:*

Change the type of the parameter so it matches the requested type.
