### PR TITLE
PS-9286 Adding support for library versioning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+.. _v0.2.1:
+
+0.2.1 - 2024-08-08
+~~~~~~~~~~~~~~~~~~
+
+* Add library version funnction "const char* kmip_library_version()". See KMIP_LIBRARY_VERSION in kmip.h
+
 .. _v0.2:
 
 0.2 - July 12, 2019

--- a/libkmip/include/kmip.h
+++ b/libkmip/include/kmip.h
@@ -43,6 +43,8 @@ typedef int64 intptr;
 typedef float real32;
 typedef double real64;
 
+#define KMIP_LIBRARY_VERSION "0.2.1"
+
 #define KMIP_TRUE (1)
 #define KMIP_FALSE (0)
 
@@ -1462,6 +1464,11 @@ do                                                      \
 } while(0)
 
 #define CALCULATE_PADDING(A) ((8 - ((A) % 8)) % 8)
+
+/*
+KMIP library version
+*/
+inline const char* kmip_libray_version(){ return KMIP_LIBRARY_VERSION; }
 
 /*
 Miscellaneous Utilities


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9286

This patch adds kmip_library_versioon() function that returns the standard version as a text.
Version bumped to 0.2.1