### PR TITLE
PS-9416 adding error messages from SSL level in kmippp

### DIFF
--- a/kmippp/CMakeLists.txt
+++ b/kmippp/CMakeLists.txt
@@ -2,6 +2,8 @@
 add_library(
   kmippp
   STATIC
+  core_error.hpp
+  core_error.cpp
   kmippp.cpp
   )
 

--- a/kmippp/core_error.cpp
+++ b/kmippp/core_error.cpp
@@ -1,0 +1,48 @@
+/* Copyright (c) 2022 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include <array>
+#include <cassert>
+
+#include <openssl/err.h>
+
+#include <core_error.hpp>
+
+namespace kmippp {
+
+static constexpr std::size_t error_message_buffer_size = 256;
+
+/* static */
+[[noreturn]] void core_error::raise_with_error_string(
+    const std::string &prefix /* = std::string() */) {
+  std::string message{prefix};
+
+  using buffer_type = std::array<char, error_message_buffer_size>;
+  buffer_type buffer;
+
+  unsigned long err = ERR_get_error();
+  if (err != 0) {
+    if (!prefix.empty()) message += ": ";
+
+    ERR_error_string_n(err, buffer.data(), buffer.size());
+    message += buffer.data();
+    ERR_clear_error();
+  }
+
+  throw core_error{message};
+}
+
+}  // namespace kmippp

--- a/kmippp/core_error.hpp
+++ b/kmippp/core_error.hpp
@@ -1,0 +1,36 @@
+/* Copyright (c) 2022 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef KMIPPP_CORE_ERROR_HPP
+#define KMIPPP_CORE_ERROR_HPP
+
+#include <stdexcept>
+#include <string>
+
+namespace kmippp {
+
+class core_error : public std::runtime_error {
+ public:
+  explicit core_error(const char *message) : std::runtime_error{message} {}
+  explicit core_error(const std::string &message) : std::runtime_error{message} {}
+
+  [[noreturn]] static void raise_with_error_string(
+      const std::string &prefix = std::string());
+};
+
+}  // namespace kmippp
+
+#endif

--- a/kmippp/kmippp.cpp
+++ b/kmippp/kmippp.cpp
@@ -12,6 +12,7 @@
 #include "kmip.h"
 #include "kmip_bio.h"
 #include "kmip_locate.h"
+#include "core_error.hpp"
 
 namespace kmippp {
 
@@ -25,24 +26,24 @@ context::context(std::string server_address,
     if(SSL_CTX_use_certificate_file(ctx_, client_cert_fn.c_str(), SSL_FILETYPE_PEM) != 1)
     {
         SSL_CTX_free(ctx_);
-        throw std::runtime_error("Loading the client certificate failed");
+        core_error::raise_with_error_string("Loading the client certificate failed");
     }
     if(SSL_CTX_use_PrivateKey_file(ctx_, client_key_fn.c_str(), SSL_FILETYPE_PEM) != 1)
     {
         SSL_CTX_free(ctx_);
-        throw std::runtime_error("Loading the client key failed");
+        core_error::raise_with_error_string("Loading the client key failed");
     }
     if(SSL_CTX_load_verify_locations(ctx_, ca_cert_fn.c_str(), nullptr) != 1)
     {
         SSL_CTX_free(ctx_);
-        throw std::runtime_error("Loading the CA certificate failed");
+        core_error::raise_with_error_string("Loading the CA certificate failed");
     }
 
     bio_ = BIO_new_ssl_connect(ctx_);
     if(bio_ == nullptr)
     {
         SSL_CTX_free(ctx_);
-        throw std::runtime_error("BIO_new_ssl_connect failed");
+        core_error::raise_with_error_string("BIO_new_ssl_connect failed");
     }
     
     SSL *ssl = nullptr;
@@ -54,7 +55,7 @@ context::context(std::string server_address,
     {
         BIO_free_all(bio_);
         SSL_CTX_free(ctx_);
-        throw std::runtime_error("BIO_do_connect failed");
+        core_error::raise_with_error_string("BIO_do_connect failed");
     }
 
 }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9416

This is very small improvement of the error messages in KMIP C++ library. It adds error of SSL level. To provide full error logging, additional woek is required. Most messages from the low-level kmip llibray are getting lost in the BIO level because context is destroyed before return to the C++ wrapper. So, to provide consistent error messages, it is required to re-write C++ wraper bypassing BIO level, in the similar way the "Mongo" project did.