### PR TITLE
Simple version added to the library

### DIFF
--- a/libkmip/include/kmip.h
+++ b/libkmip/include/kmip.h
@@ -13,6 +13,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "libkmip_version.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/libkmip/include/libkmip_version.h
+++ b/libkmip/include/libkmip_version.h
@@ -1,0 +1,17 @@
+#ifndef LIBKMIP_VERSION_H
+#define LIBKMIP_VERSION_H
+
+
+#define KMIP_LIB_VERSION_MAJOR 0
+#define KMIP_LIB_VERSION_MINOR 2
+#define KMIP_LIB_VERSION_PATCH 0
+
+#define KMIP_LIB_STRINGIFY_I(x) #x
+#define KMIP_LIB_TOSTRING_I(x)  KMIP_LIB_STRINGIFY_I (x)
+
+#define KMIP_LIB_VERSION_STR                                                                                           \
+  KMIP_LIB_TOSTRING_I (KMIP_LIB_VERSION_MAJOR)                                                                         \
+  "." KMIP_LIB_TOSTRING_I (KMIP_LIB_VERSION_MINOR) "." KMIP_LIB_TOSTRING_I (KMIP_LIB_VERSION_PATCH)
+
+
+#endif // LIBKMIP_VERSION_H

--- a/libkmip/src/demo_create.c
+++ b/libkmip/src/demo_create.c
@@ -19,6 +19,7 @@
 void
 print_help (const char *app)
 {
+  printf("libkmip version: %s \n", KMIP_LIB_VERSION_STR);
   printf ("Usage: %s [flag value | flag] ...\n\n", app);
   printf ("Flags:\n");
   printf ("-a addr : the IP address of the KMIP server\n");

--- a/libkmip/src/demo_destroy.c
+++ b/libkmip/src/demo_destroy.c
@@ -18,6 +18,7 @@
 void
 print_help (const char *app)
 {
+  printf("libkmip version: %s \n", KMIP_LIB_VERSION_STR);
   printf ("Usage: %s [flag value | flag] ...\n\n", app);
   printf ("Flags:\n");
   printf ("-a addr : the IP address of the KMIP server\n");

--- a/libkmip/src/demo_get.c
+++ b/libkmip/src/demo_get.c
@@ -19,6 +19,7 @@
 void
 print_help (const char *app)
 {
+  printf("libkmip version: %s \n", KMIP_LIB_VERSION_STR);
   printf ("Usage: %s [flag value | flag] ...\n\n", app);
   printf ("Flags:\n");
   printf ("-a addr : the IP address of the KMIP server\n");

--- a/libkmip/src/demo_locate.c
+++ b/libkmip/src/demo_locate.c
@@ -21,6 +21,7 @@
 void
 print_help (const char *app)
 {
+  printf("libkmip version: %s \n", KMIP_LIB_VERSION_STR);
   printf ("Usage: %s [flag value | flag] ...\n\n", app);
   printf ("Flags:\n");
   printf ("-a addr : the IP address of the KMIP server\n");

--- a/libkmip/src/demo_query.c
+++ b/libkmip/src/demo_query.c
@@ -19,6 +19,7 @@
 void
 print_help (const char *app)
 {
+  printf("libkmip version: %s \n", KMIP_LIB_VERSION_STR);
   printf ("Usage: %s [flag value | flag] ...\n\n", app);
   printf ("Flags:\n");
   printf ("-a addr : the IP address of the KMIP server\n");

--- a/libkmip/src/demo_register.c
+++ b/libkmip/src/demo_register.c
@@ -19,6 +19,7 @@
 void
 print_help (const char *app)
 {
+  printf("libkmip version: %s \n", KMIP_LIB_VERSION_STR);
   printf ("Usage: %s [flag value | flag] ...\n\n", app);
   printf ("Flags:\n");
   printf ("-a addr : the IP address of the KMIP server\n");


### PR DESCRIPTION
 Simple version added to the library by introducing static global variable libkmip_version.

This is standard 3-number version. Initial value for this commit is 0.2.0 Each time the new functionality is added, the minor version should be incremented. Each time the bugfix or other small code change happens, the revision number should be incremented.

PS. Before  merge of versioning trunk will be tagged as version-0.1.9, after merge it will be tagged as version-0.2.0. Then will tag each minor version change and not tag a revision change. 