### PR TITLE
PS-9673 fixes a bug of ignoring server side error

### DIFF
--- a/libkmip/include/kmip.h
+++ b/libkmip/include/kmip.h
@@ -73,6 +73,7 @@ typedef int64 intptr;
 #define KMIP_INVALID_ENCODING        (-19)
 #define KMIP_INVALID_FIELD           (-20)
 #define KMIP_INVALID_LENGTH          (-21)
+#define KMIP_ERROR_SERVERSIDE        (-22)
 
   /*
   Enumerations

--- a/libkmip/src/demo_get.c
+++ b/libkmip/src/demo_get.c
@@ -226,13 +226,13 @@ use_mid_level_api (char *server_address, char *server_port, char *client_certifi
   printf ("\n");
   if (result < 0)
     {
-      printf ("An error occurred while creating the symmetric key.");
-      printf ("Error Code: %d\n", result);
-      printf ("Error Name: ");
+      fprintf (stderr, "An error occurred while getting the symmetric key. ");
+      fprintf (stderr, "Error Code: %d\n", result);
+      fprintf (stderr, "Error Name: ");
       kmip_print_error_string (stderr, result);
-      printf ("\n");
-      printf ("Context Error: %s\n", kmip_context.error_message);
-      printf ("Stack trace:\n");
+      fprintf (stderr, "\n");
+      fprintf (stderr, "Context Error: %s\n", kmip_context.error_message);
+      fprintf (stderr, "Stack trace:\n");
       kmip_print_stack_trace (stderr, &kmip_context);
     }
   else if (result >= 0)

--- a/libkmip/src/kmip.c
+++ b/libkmip/src/kmip.c
@@ -1961,6 +1961,30 @@ kmip_print_error_string (FILE *f, int value)
       }
       break;
 
+    case -19:
+      {
+        fprintf (f, "KMIP_INVALID_ENCODING");
+      }
+      break;
+
+    case -20:
+      {
+        fprintf (f, "KMIP_INVALID_FIELD");
+      }
+      break;
+
+    case -21:
+      {
+        fprintf (f, "KMIP_INVALID_LENGTH");
+      }
+      break;
+
+    case -22:
+      {
+        fprintf (f, "KMIP_ERROR_SERVERSIDE");
+      }
+      break;
+
     default:
       {
         fprintf (f, "Unrecognized Error Code");
@@ -14792,6 +14816,13 @@ kmip_decode_response_batch_item (KMIP *ctx, ResponseBatchItem *value)
       result = kmip_decode_byte_string (ctx, KMIP_TAG_ASYNCHRONOUS_CORRELATION_VALUE,
                                         value->asynchronous_correlation_value);
       CHECK_RESULT (ctx, result);
+    }
+  //In case of some error reported by server we should not decode response payload because it is empty
+  if (value->result_status == KMIP_STATUS_OPERATION_FAILED)
+    {
+      kmip_set_error_message(ctx, value->result_message->value);
+      kmip_push_error_frame (ctx, __func__, __LINE__);
+      return KMIP_ERROR_SERVERSIDE;
     }
 
   /* NOTE (ph) Omitting the tag check is a good way to test error output. */


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9673

The server reported error has been ignored in the kmip.c:kmip_decode_response_batch_item() and the code continued parsing of the batch item, which usually contains some garbage. It may cause memory corruption or just strange error messagers. This patch interrups parsing and sets appropriate error message from the server to the KMIP context.