### PR TITLE
PS-9861 fix of secret get operation, key format type RAW added

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@ Changelog
 =========
 0.3.3 - July 2025 
 ~~~~~~~~~~~~~~~~~~~~~~
-* Fix of register secret operation usage mask, Fortanix server
+* The register secret operation usage mask fixed, works Fortanix server
+* The get secret operation key format type fixed, works Fortanix server
 
 0.3.2: -- May 2025
 ~~~~~~~~~~~~~~~~~~~~~

--- a/libkmip/src/kmip_bio.c
+++ b/libkmip/src/kmip_bio.c
@@ -3093,7 +3093,8 @@ kmip_bio_get_secret (BIO *bio, char *id, int id_size, char **key, int *key_size)
 
   SecretData *secret = (SecretData *)pld->object;
   KeyBlock   *block  = secret->key_block;
-  if ((block->key_format_type != KMIP_KEYFORMAT_OPAQUE) || (block->key_wrapping_data != NULL))
+  if ( ! (block->key_format_type == KMIP_KEYFORMAT_OPAQUE || block->key_format_type == KMIP_KEYFORMAT_RAW)
+       || (block->key_wrapping_data != NULL))
     {
       kmip_free_response_message (&ctx, &resp_m);
       kmip_set_buffer (&ctx, NULL, 0);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9861

The key format type RAW added besides OPAQUE to support Fortanix server. Now "GET SECRET" operations works correct