### PR TITLE
Fix warning shadowing result variable in the #define CHECK_ENUM

### DIFF
--- a/libkmip/include/kmip.h
+++ b/libkmip/include/kmip.h
@@ -1491,12 +1491,12 @@ typedef int64 intptr;
 #define CHECK_ENUM(A, B, C)                                                                                            \
   do                                                                                                                   \
     {                                                                                                                  \
-      int result = kmip_check_enum_value ((A)->version, (B), (C));                                                     \
-      if (result != KMIP_OK)                                                                                           \
+      int __result = kmip_check_enum_value ((A)->version, (B), (C));                                                     \
+      if (__result != KMIP_OK)                                                                                           \
         {                                                                                                              \
-          kmip_set_enum_error_message ((A), (B), (C), result);                                                         \
+          kmip_set_enum_error_message ((A), (B), (C), __result);                                                         \
           kmip_push_error_frame ((A), __func__, __LINE__);                                                             \
-          return (result);                                                                                             \
+          return (__result);                                                                                             \
         }                                                                                                              \
     }                                                                                                                  \
   while (0)


### PR DESCRIPTION
Hello, in the macros `CHECK_ENUM` we need to remove `int`, i.e. not create a `result` var. Or change a name to another.
I think, renaming is more safe

```
In file included from src/libkmip/libkmip/src/kmip.c:15: src/libkmip/libkmip/src/kmip.c: In function ‘kmip_decode_name’: ../../contrib/pg_tde/src/libkmip/libkmip/include/kmip.h:1414:9: warning: declaration of ‘result’ shadows a previous local [-Wshadow=compatible-local]
     int result = kmip_check_enum_value((A)->version, (B), (C)); \
         ^~~~~~
src/libkmip/libkmip/src/kmip.c:12759:5: note: in expansion of macro ‘CHECK_ENUM’
     CHECK_ENUM(ctx, KMIP_TAG_NAME_TYPE, value->type);
     ^~~~~~~~~~
src/libkmip/libkmip/src/kmip.c:12742:9: note: shadowed declaration is here
     int result = 0;
         ^~~~~~
```