### PR TITLE
 PS-10949 Fix leaks in revoke/secret/server-info paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,43 @@ For more information on KMIP, check out the
 
 For more information on libkmip, check out the project [Documentation][docs].
 
+## Build
+
+Build with CMake:
+
+```bash
+cmake -S . -B cmake-build-debug
+cmake --build cmake-build-debug -j
+```
+
+## Run Demos
+
+Demo binaries are created in `cmake-build-debug/libkmip/src/`.
+For example:
+
+```bash
+./cmake-build-debug/libkmip/src/demo_query
+```
+
+## Run Tests (ASAN)
+
+An AddressSanitizer + LeakSanitizer test target is available for
+`libkmip/src/tests.c`:
+
+```bash
+cmake --build cmake-build-debug --target run_tests_asan
+```
+
+This command builds and runs `kmip_tests_asan` with leak detection enabled.
+
 ## Installation
 
-You can install libkmip from source using `make`:
+You can also install libkmip from source using `make`:
 
-```
-$ cd libkmip
-$ make
-$ make install
+```bash
+cd libkmip
+make
+make install
 ```
 
 See [Installation][install] for more information.

--- a/libkmip/include/kmip.h
+++ b/libkmip/include/kmip.h
@@ -1726,6 +1726,7 @@ typedef int64 intptr;
   void kmip_free_symmetric_key (KMIP *, SymmetricKey *);
   void kmip_free_public_key (KMIP *, PublicKey *);
   void kmip_free_private_key (KMIP *, PrivateKey *);
+  void kmip_free_secret_data (KMIP *, SecretData *);
   void kmip_free_key_wrapping_specification (KMIP *, KeyWrappingSpecification *);
   void kmip_free_create_request_payload (KMIP *, CreateRequestPayload *);
   void kmip_free_create_response_payload (KMIP *, CreateResponsePayload *);

--- a/libkmip/src/CMakeLists.txt
+++ b/libkmip/src/CMakeLists.txt
@@ -45,3 +45,41 @@ add_demo(get)
 add_demo(locate)
 add_demo(register)
 add_demo(query)
+
+# ASAN-enabled test runner for libkmip/src/tests.c.
+add_executable(
+  kmip_tests_asan
+  tests.c
+  kmip_bio.c
+  kmip.c
+  kmip_locate.c
+  kmip_memset.c
+)
+
+target_include_directories(
+  kmip_tests_asan PRIVATE
+  ${KMIP_SOURCE_DIR}/libkmip/include/
+)
+
+target_link_libraries(kmip_tests_asan OpenSSL::SSL OpenSSL::Crypto)
+
+target_compile_options(
+  kmip_tests_asan PRIVATE
+  -fsanitize=address
+  -fno-omit-frame-pointer
+  -include
+  stdio.h
+)
+
+target_link_options(
+  kmip_tests_asan PRIVATE
+  -fsanitize=address
+)
+
+add_custom_target(
+  run_tests_asan
+  COMMAND ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:halt_on_error=1 $<TARGET_FILE:kmip_tests_asan>
+  DEPENDS kmip_tests_asan
+  USES_TERMINAL
+)
+

--- a/libkmip/src/kmip.c
+++ b/libkmip/src/kmip.c
@@ -6855,14 +6855,47 @@ kmip_free_objects (KMIP *ctx, ObjectTypes *value)
 void
 kmip_free_server_information (KMIP *ctx, ServerInformation *value)
 {
-  kmip_free_text_string (ctx, value->server_name);
-  kmip_free_text_string (ctx, value->server_serial_number);
-  kmip_free_text_string (ctx, value->server_version);
-  kmip_free_text_string (ctx, value->server_load);
-  kmip_free_text_string (ctx, value->product_name);
-  kmip_free_text_string (ctx, value->build_level);
-  kmip_free_text_string (ctx, value->build_date);
-  kmip_free_text_string (ctx, value->cluster_info);
+  if (ctx == NULL || value == NULL)
+    return;
+
+#define FREE_TEXT_FIELD(field)                          \
+  if (value->field != NULL)                             \
+    {                                                   \
+      kmip_free_text_string (ctx, value->field);        \
+      ctx->free_func (ctx->state, value->field);        \
+      value->field = NULL;                              \
+    }
+
+  FREE_TEXT_FIELD (server_name)
+  FREE_TEXT_FIELD (server_serial_number)
+  FREE_TEXT_FIELD (server_version)
+  FREE_TEXT_FIELD (server_load)
+  FREE_TEXT_FIELD (product_name)
+  FREE_TEXT_FIELD (build_level)
+  FREE_TEXT_FIELD (build_date)
+  FREE_TEXT_FIELD (cluster_info)
+
+#undef FREE_TEXT_FIELD
+
+  if (value->alternative_failover_endpoints != NULL)
+    {
+      AltEndpoints *alt = value->alternative_failover_endpoints;
+      if (alt->endpoint_list != NULL)
+        {
+          LinkedListItem *item = kmip_linked_list_pop (alt->endpoint_list);
+          while (item != NULL)
+            {
+              kmip_free_text_string (ctx, (TextString *)item->data);
+              ctx->free_func (ctx->state, item->data);
+              ctx->free_func (ctx->state, item);
+              item = kmip_linked_list_pop (alt->endpoint_list);
+            }
+          ctx->free_func (ctx->state, alt->endpoint_list);
+          alt->endpoint_list = NULL;
+        }
+      ctx->free_func (ctx->state, value->alternative_failover_endpoints);
+      value->alternative_failover_endpoints = NULL;
+    }
 }
 
 /*
@@ -12450,6 +12483,10 @@ kmip_encode_response_batch_item (KMIP *ctx, const ResponseBatchItem *value)
 
     case KMIP_OP_REGISTER:
       result = kmip_encode_register_response_payload (ctx, (RegisterResponsePayload *)value->response_payload);
+      break;
+
+    case KMIP_OP_GET:
+      result = kmip_encode_get_response_payload (ctx, (GetResponsePayload *)value->response_payload);
       break;
 
     case KMIP_OP_GET_ATTRIBUTES:

--- a/libkmip/src/kmip.c
+++ b/libkmip/src/kmip.c
@@ -5805,6 +5805,24 @@ kmip_free_private_key (KMIP *ctx, PrivateKey *value)
 }
 
 void
+kmip_free_secret_data (KMIP *ctx, SecretData *value)
+{
+  if (value != NULL)
+    {
+      if (value->key_block != NULL)
+        {
+          kmip_free_key_block (ctx, value->key_block);
+          ctx->free_func (ctx->state, value->key_block);
+          value->key_block = NULL;
+        }
+
+      value->secret_data_type = 0;
+    }
+
+  return;
+}
+
+void
 kmip_free_key_wrapping_specification (KMIP *ctx, KeyWrappingSpecification *value)
 {
   if (value != NULL)
@@ -6030,6 +6048,10 @@ kmip_free_get_response_payload (KMIP *ctx, GetResponsePayload *value)
               kmip_free_private_key (ctx, (PrivateKey *)value->object);
               break;
 
+            case KMIP_OBJTYPE_SECRET_DATA:
+              kmip_free_secret_data (ctx, (SecretData *)value->object);
+              break;
+
             default:
               /* NOTE (ph) Hitting this case means that we don't know */
               /*      what the actual type, size, or value of         */
@@ -6140,6 +6162,54 @@ kmip_free_destroy_response_payload (KMIP *ctx, DestroyResponsePayload *value)
 }
 
 void
+kmip_free_revoke_request_payload (KMIP *ctx, RevokeRequestPayload *value)
+{
+  if (value != NULL)
+    {
+      if (value->unique_identifier != NULL)
+        {
+          kmip_free_text_string (ctx, value->unique_identifier);
+          ctx->free_func (ctx->state, value->unique_identifier);
+          value->unique_identifier = NULL;
+        }
+
+      if (value->revocation_reason != NULL)
+        {
+          if (value->revocation_reason->message != NULL)
+            {
+              kmip_free_text_string (ctx, value->revocation_reason->message);
+              ctx->free_func (ctx->state, value->revocation_reason->message);
+              value->revocation_reason->message = NULL;
+            }
+
+          value->revocation_reason->reason = 0;
+          ctx->free_func (ctx->state, value->revocation_reason);
+          value->revocation_reason = NULL;
+        }
+
+      value->compromise_occurence_date = 0;
+    }
+
+  return;
+}
+
+void
+kmip_free_revoke_response_payload (KMIP *ctx, RevokeResponsePayload *value)
+{
+  if (value != NULL)
+    {
+      if (value->unique_identifier != NULL)
+        {
+          kmip_free_text_string (ctx, value->unique_identifier);
+          ctx->free_func (ctx->state, value->unique_identifier);
+          value->unique_identifier = NULL;
+        }
+    }
+
+  return;
+}
+
+void
 kmip_free_request_batch_item (KMIP *ctx, RequestBatchItem *value)
 {
   if (value != NULL)
@@ -6185,6 +6255,10 @@ kmip_free_request_batch_item (KMIP *ctx, RequestBatchItem *value)
 
             case KMIP_OP_LOCATE:
               kmip_free_locate_request_payload (ctx, (LocateRequestPayload *)value->request_payload);
+              break;
+
+            case KMIP_OP_REVOKE:
+              kmip_free_revoke_request_payload (ctx, (RevokeRequestPayload *)value->request_payload);
               break;
 
             default:
@@ -6270,6 +6344,10 @@ kmip_free_response_batch_item (KMIP *ctx, ResponseBatchItem *value)
 
             case KMIP_OP_LOCATE:
               kmip_free_locate_response_payload (ctx, (LocateResponsePayload *)value->response_payload);
+              break;
+
+            case KMIP_OP_REVOKE:
+              kmip_free_revoke_response_payload (ctx, (RevokeResponsePayload *)value->response_payload);
               break;
 
             default:

--- a/libkmip/src/tests.c
+++ b/libkmip/src/tests.c
@@ -9987,6 +9987,7 @@ test_encode_query_request_payload (TestTracker *tracker)
   int result = kmip_encode_query_request_payload (&ctx, &qrp);
   result     = report_encoding_test_result (tracker, &ctx, expected, observed, result, __func__);
 
+  kmip_destroy (&ctx);
   return (result);
 }
 

--- a/libkmip/src/tests.c
+++ b/libkmip/src/tests.c
@@ -5548,6 +5548,150 @@ test_decode_get_response_payload (TestTracker *tracker)
 }
 
 int
+test_decode_get_response_payload_secret_data (TestTracker *tracker)
+{
+  TRACK_TEST (tracker);
+
+  uint8       encoding[256] = { 0 };
+  struct kmip encode_ctx    = { 0 };
+  kmip_init (&encode_ctx, encoding, ARRAY_LENGTH (encoding), KMIP_1_0);
+
+  struct text_string uuid = { 0 };
+  uuid.value              = "secret-data-id";
+  uuid.size               = 14;
+
+  uint8              key_material[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+  struct byte_string key_bytes       = { 0 };
+  key_bytes.value                    = key_material;
+  key_bytes.size                     = ARRAY_LENGTH (key_material);
+
+  struct key_value kv = { 0 };
+  kv.key_material     = &key_bytes;
+
+  struct key_block kb        = { 0 };
+  kb.key_format_type         = KMIP_KEYFORMAT_RAW;
+  kb.key_value               = &kv;
+  kb.cryptographic_algorithm = KMIP_CRYPTOALG_AES;
+  kb.cryptographic_length    = 128;
+
+  struct secret_data secret = { 0 };
+  secret.secret_data_type   = PASSWORD;
+  secret.key_block          = &kb;
+
+  int    result       = 0;
+  uint8 *length_index = NULL;
+  uint8 *value_index  = NULL;
+  uint8 *curr_index   = NULL;
+
+  result = kmip_encode_int32_be (&encode_ctx, TAG_TYPE (KMIP_TAG_RESPONSE_PAYLOAD, KMIP_TYPE_STRUCTURE));
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+
+  length_index = encode_ctx.index;
+  value_index  = encode_ctx.index += 4;
+
+  result = kmip_encode_enum (&encode_ctx, KMIP_TAG_OBJECT_TYPE, KMIP_OBJTYPE_SECRET_DATA);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+  result = kmip_encode_text_string (&encode_ctx, KMIP_TAG_UNIQUE_IDENTIFIER, &uuid);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+  result = kmip_encode_int32_be (&encode_ctx, TAG_TYPE (KMIP_TAG_SECRET_DATA, KMIP_TYPE_STRUCTURE));
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+
+  uint8 *secret_length_index = encode_ctx.index;
+  uint8 *secret_value_index  = encode_ctx.index += 4;
+
+  result = kmip_encode_enum (&encode_ctx, KMIP_TAG_SECRET_DATA_TYPE, secret.secret_data_type);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+
+  result = kmip_encode_key_block (&encode_ctx, secret.key_block);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+
+  curr_index       = encode_ctx.index;
+  encode_ctx.index = secret_length_index;
+
+  result = kmip_encode_length (&encode_ctx, curr_index - secret_value_index);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+  encode_ctx.index = curr_index;
+
+  curr_index       = encode_ctx.index;
+  encode_ctx.index  = length_index;
+
+  result = kmip_encode_length (&encode_ctx, curr_index - value_index);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+  encode_ctx.index = curr_index;
+
+  size_t decode_size = (size_t)(encode_ctx.index - encode_ctx.buffer);
+
+  struct kmip decode_ctx = { 0 };
+  kmip_init (&decode_ctx, encoding, decode_size, KMIP_1_0);
+
+  struct get_response_payload observed = { 0 };
+  result                              = kmip_decode_get_response_payload (&decode_ctx, &observed);
+
+  int comparison = 0;
+  if (result == KMIP_OK)
+    {
+      SecretData *decoded_secret = (SecretData *)observed.object;
+      KeyValue   *decoded_kv = (decoded_secret != NULL) ? (KeyValue *)decoded_secret->key_block->key_value : NULL;
+      ByteString *decoded_material = (decoded_kv != NULL) ? (ByteString *)decoded_kv->key_material : NULL;
+      comparison = (observed.object_type == KMIP_OBJTYPE_SECRET_DATA) && (observed.unique_identifier != NULL)
+                   && (observed.unique_identifier->size == uuid.size)
+                   && (memcmp (observed.unique_identifier->value, uuid.value, uuid.size) == 0)
+                   && (decoded_secret != NULL) && (decoded_secret->secret_data_type == PASSWORD)
+                   && (decoded_secret->key_block != NULL) && (decoded_kv != NULL) && (decoded_material != NULL)
+                   && (decoded_material->size == ARRAY_LENGTH (key_material))
+                   && (memcmp (decoded_material->value, key_material, ARRAY_LENGTH (key_material))
+                       == 0);
+    }
+
+  result = report_decoding_test_result (tracker, &decode_ctx, comparison, result, __func__);
+
+  kmip_free_get_response_payload (&decode_ctx, &observed);
+  kmip_destroy (&decode_ctx);
+  kmip_destroy (&encode_ctx);
+  return (result);
+}
+
+int
 test_encode_destroy_request_payload (TestTracker *tracker)
 {
   TRACK_TEST (tracker);
@@ -6367,6 +6511,61 @@ test_decode_response_batch_item_get_payload (TestTracker *tracker)
                                         __func__);
   kmip_free_response_batch_item (&ctx, &observed);
   kmip_destroy (&ctx);
+  return (result);
+}
+
+int
+test_decode_response_batch_item_revoke_payload (TestTracker *tracker)
+{
+  TRACK_TEST (tracker);
+
+  uint8       encoding[128] = { 0 };
+  struct kmip encode_ctx    = { 0 };
+  kmip_init (&encode_ctx, encoding, ARRAY_LENGTH (encoding), KMIP_1_0);
+
+  struct text_string uuid = { 0 };
+  uuid.value              = "revoke-id";
+  uuid.size               = 9;
+
+  struct revoke_response_payload payload = { 0 };
+  payload.unique_identifier              = &uuid;
+
+  struct response_batch_item item = { 0 };
+  item.operation                  = KMIP_OP_REVOKE;
+  item.result_status              = KMIP_STATUS_SUCCESS;
+  item.response_payload           = &payload;
+
+  int result = kmip_encode_response_batch_item (&encode_ctx, &item);
+  if (result != KMIP_OK)
+    {
+      result = report_result (tracker, result, KMIP_OK, __func__);
+      kmip_destroy (&encode_ctx);
+      return (result);
+    }
+
+  size_t decode_size = (size_t)(encode_ctx.index - encode_ctx.buffer);
+
+  struct kmip decode_ctx = { 0 };
+  kmip_init (&decode_ctx, encoding, decode_size, KMIP_1_0);
+
+  struct response_batch_item observed = { 0 };
+  result                             = kmip_decode_response_batch_item (&decode_ctx, &observed);
+
+  int comparison = 0;
+  if (result == KMIP_OK)
+    {
+      RevokeResponsePayload *decoded_payload = (RevokeResponsePayload *)observed.response_payload;
+      comparison = (observed.operation == KMIP_OP_REVOKE) && (observed.result_status == KMIP_STATUS_SUCCESS)
+                   && (decoded_payload != NULL) && (decoded_payload->unique_identifier != NULL)
+                   && (decoded_payload->unique_identifier->size == uuid.size)
+                   && (memcmp (decoded_payload->unique_identifier->value, uuid.value, uuid.size) == 0);
+    }
+
+  result = report_decoding_test_result (tracker, &decode_ctx, comparison, result, __func__);
+
+  kmip_free_response_batch_item (&decode_ctx, &observed);
+  kmip_destroy (&decode_ctx);
+  kmip_destroy (&encode_ctx);
   return (result);
 }
 
@@ -10355,9 +10554,11 @@ run_tests (void)
   test_decode_create_response_payload_with_template_attribute (&tracker);
   test_decode_get_request_payload (&tracker);
   test_decode_get_response_payload (&tracker);
+  test_decode_get_response_payload_secret_data (&tracker);
   test_decode_destroy_request_payload (&tracker);
   test_decode_destroy_response_payload (&tracker);
   test_decode_response_batch_item_get_payload (&tracker);
+  test_decode_response_batch_item_revoke_payload (&tracker);
   test_decode_username_password_credential (&tracker);
   test_decode_credential_username_password_credential (&tracker);
   test_decode_authentication_username_password_credential (&tracker);


### PR DESCRIPTION
 PS-10949 Fix leaks in revoke/secret/server-info paths; encode GET responses

 https://perconadev.atlassian.net/browse/PS-10949

The summary of fixes from the 1st commit :

   PS-10949 Fix revoke/SecretData decode leaks and add ASAN test target 
     
    https://perconadev.atlassian.net/browse/PS-10949 
     
    libkmip/src/kmip.c: adds missing free paths to prevent decode-time leaks: 
    new kmip_free_secret_data(...) 
    new kmip_free_revoke_request_payload(...) 
    new kmip_free_revoke_response_payload(...) 
     
    wires these into existing dispatch in kmip_free_get_response_payload, 
    kmip_free_request_batch_item, and kmip_free_response_batch_item for 
    KMIP_OBJTYPE_SECRET_DATA and KMIP_OP_REVOKE. 
     
    libkmip/include/kmip.h: exports kmip_free_secret_data(...) declaration. 
    libkmip/src/tests.c: adds regression tests for decode paths that were leaking: 
    test_decode_get_response_payload_secret_data 
    test_decode_response_batch_item_revoke_payload 
    both added to run_tests(). 
     
    libkmip/src/CMakeLists.txt: introduces ASAN/LSAN test executable kmip_tests_asan and 
    custom target run_tests_asan with leak detection enabled. 
     
    README.md: updates usage docs with CMake build/run instructions and adds a 
    “Run Tests (ASAN)” section showing run_tests_asan.
 

The second commit fixes other leaks detected by tests.c run with ASAN:

   PS-10949 Fix remaining leask detected by ASAN test target 
     
    https://perconadev.atlassian.net/browse/PS-10949 
     
    libkmip/src/kmip.c 
     
    kmip_free_server_information was expanded from shallow field cleanup 
    to full owned-memory cleanup. 
     
    Adds a null guard (ctx/value) and explicitly frees each allocated 
    TextString * field pointer after kmip_free_text_string. 
     
    Adds cleanup for alternative_failover_endpoints, including draining/freing 
    endpoint_list items and container allocations. 
     
    Adds KMIP_OP_GET handling in kmip_encode_response_batch_item to encode 
    GetResponsePayload (previously missing in that switch). 
     
    libkmip/src/tests.c 
    In test_encode_query_request_payload, adds kmip_destroy(&ctx) before return, 
    fixing leaked test context memory. 
     
    Net effect: this commit closes additional ASAN-reported leaks in server-info/test code paths and fixes missing 
    GET response-payload encoding dispatch.

 