### PR TITLE
Ps 10949 clang20 fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION  3.5.0)
+cmake_minimum_required(VERSION  3.10.0)
 
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
@@ -7,6 +7,50 @@ endif(POLICY CMP0048)
 project(kmip C CXX)
 
 set(KMIP_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+option(WITH_ASAN "Enable AddressSanitizer for project build" OFF)
+option(BUILD_KMIP_TESTS "Build and register libkmip/src/tests.c with CTest" OFF)
+
+if(BUILD_KMIP_TESTS)
+  enable_testing()
+endif()
+
+if(WITH_ASAN)
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU" AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    set(_asan_compile_flags "-fsanitize=address -fno-omit-frame-pointer")
+    set(_asan_link_flags "-fsanitize=address")
+
+    string(APPEND CMAKE_C_FLAGS " ${_asan_compile_flags}")
+    string(APPEND CMAKE_CXX_FLAGS " ${_asan_compile_flags}")
+    string(APPEND CMAKE_EXE_LINKER_FLAGS " ${_asan_link_flags}")
+    string(APPEND CMAKE_SHARED_LINKER_FLAGS " ${_asan_link_flags}")
+  else()
+    message(FATAL_ERROR "WITH_ASAN=ON is supported only with Clang or GCC compilers")
+  endif()
+endif()
+
+# Keep Clang-20+ builds quiet even when user environments inject strict warning flags.
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 20)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:C>:-Wno-c23-extensions>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-invalid-utf8>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-newline-eof>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-sign-compare>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-unused-parameter>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-unused-variable>
+  )
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 20)
+  add_compile_options(
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-utf8>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-field-initializers>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-sign-compare>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-parameter>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-private-field>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-variable>
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-vla-cxx-extension>
+  )
+endif()
 
 add_subdirectory(libkmip/src)
 add_subdirectory(kmippp)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ For more information on libkmip, check out the project [Documentation][docs].
 
 ## Build
 
-Build with CMake:
+Configure and build with CMake:
 
 ```bash
-cmake -S . -B cmake-build-debug
+cmake -S . -B cmake-build-debug -DCMAKE_BUILD_TYPE=Debug
 cmake --build cmake-build-debug -j
 ```
+
+By default, `BUILD_KMIP_TESTS` is `OFF`.
 
 ## Run Demos
 
@@ -34,26 +36,41 @@ For example:
 ./cmake-build-debug/libkmip/src/demo_query
 ```
 
-## Run Tests (ASAN)
+## Run Tests
 
-An AddressSanitizer + LeakSanitizer test target is available for
-`libkmip/src/tests.c`:
+Enable tests at configure time, then run them with CTest:
 
 ```bash
-cmake --build cmake-build-debug --target run_tests_asan
+cmake -S . -B cmake-build-tests -DCMAKE_BUILD_TYPE=Debug -DBUILD_KMIP_TESTS=ON
+cmake --build cmake-build-tests -j
+ctest --test-dir cmake-build-tests --output-on-failure
 ```
 
-This command builds and runs `kmip_tests_asan` with leak detection enabled.
+`BUILD_KMIP_TESTS=ON` builds `libkmip/src/tests.c` into the `kmip_tests` target
+and registers it with CTest.
+
+## Build with ASAN
+
+AddressSanitizer can be enabled with `WITH_ASAN=ON` (Clang/GCC):
+
+```bash
+cmake -S . -B cmake-build-asan -DCMAKE_BUILD_TYPE=Debug -DWITH_ASAN=ON -DBUILD_KMIP_TESTS=ON
+cmake --build cmake-build-asan -j
+ctest --test-dir cmake-build-asan --output-on-failure
+```
 
 ## Installation
 
-You can also install libkmip from source using `make`:
+Install using CMake:
 
 ```bash
-cd libkmip
-make
-make install
+cmake -S . -B cmake-build-release -DCMAKE_BUILD_TYPE=Release
+cmake --build cmake-build-release -j
+cmake --install cmake-build-release
 ```
+
+To install to a custom prefix, add
+`-DCMAKE_INSTALL_PREFIX=/your/prefix/path` when configuring.
 
 See [Installation][install] for more information.
 

--- a/libkmip/src/CMakeLists.txt
+++ b/libkmip/src/CMakeLists.txt
@@ -46,40 +46,13 @@ add_demo(locate)
 add_demo(register)
 add_demo(query)
 
-# ASAN-enabled test runner for libkmip/src/tests.c.
-add_executable(
-  kmip_tests_asan
-  tests.c
-  kmip_bio.c
-  kmip.c
-  kmip_locate.c
-  kmip_memset.c
-)
-
-target_include_directories(
-  kmip_tests_asan PRIVATE
-  ${KMIP_SOURCE_DIR}/libkmip/include/
-)
-
-target_link_libraries(kmip_tests_asan OpenSSL::SSL OpenSSL::Crypto)
-
-target_compile_options(
-  kmip_tests_asan PRIVATE
-  -fsanitize=address
-  -fno-omit-frame-pointer
-  -include
-  stdio.h
-)
-
-target_link_options(
-  kmip_tests_asan PRIVATE
-  -fsanitize=address
-)
-
-add_custom_target(
-  run_tests_asan
-  COMMAND ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:halt_on_error=1 $<TARGET_FILE:kmip_tests_asan>
-  DEPENDS kmip_tests_asan
-  USES_TERMINAL
-)
+if(BUILD_KMIP_TESTS)
+  add_executable(kmip_tests tests.c)
+  target_link_libraries(kmip_tests kmip)
+  if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
+    # tests.c includes kmip.h before stdio.h; inject stdio for this target only.
+    target_compile_options(kmip_tests PRIVATE -include stdio.h)
+  endif()
+  add_test(NAME kmip_tests COMMAND kmip_tests)
+endif()
 

--- a/libkmip/src/kmip.c
+++ b/libkmip/src/kmip.c
@@ -6856,44 +6856,81 @@ void
 kmip_free_server_information (KMIP *ctx, ServerInformation *value)
 {
   if (ctx == NULL || value == NULL)
-    return;
-
-#define FREE_TEXT_FIELD(field)                          \
-  if (value->field != NULL)                             \
-    {                                                   \
-      kmip_free_text_string (ctx, value->field);        \
-      ctx->free_func (ctx->state, value->field);        \
-      value->field = NULL;                              \
+    {
+      return;
     }
 
-  FREE_TEXT_FIELD (server_name)
-  FREE_TEXT_FIELD (server_serial_number)
-  FREE_TEXT_FIELD (server_version)
-  FREE_TEXT_FIELD (server_load)
-  FREE_TEXT_FIELD (product_name)
-  FREE_TEXT_FIELD (build_level)
-  FREE_TEXT_FIELD (build_date)
-  FREE_TEXT_FIELD (cluster_info)
-
-#undef FREE_TEXT_FIELD
+  if (value->server_name != NULL)
+    {
+      kmip_free_text_string (ctx, value->server_name);
+      ctx->free_func (ctx->state, value->server_name);
+      value->server_name = NULL;
+    }
+  if (value->server_serial_number != NULL)
+    {
+      kmip_free_text_string (ctx, value->server_serial_number);
+      ctx->free_func (ctx->state, value->server_serial_number);
+      value->server_serial_number = NULL;
+    }
+  if (value->server_version != NULL)
+    {
+      kmip_free_text_string (ctx, value->server_version);
+      ctx->free_func (ctx->state, value->server_version);
+      value->server_version = NULL;
+    }
+  if (value->server_load != NULL)
+    {
+      kmip_free_text_string (ctx, value->server_load);
+      ctx->free_func (ctx->state, value->server_load);
+      value->server_load = NULL;
+    }
+  if (value->product_name != NULL)
+    {
+      kmip_free_text_string (ctx, value->product_name);
+      ctx->free_func (ctx->state, value->product_name);
+      value->product_name = NULL;
+    }
+  if (value->build_level != NULL)
+    {
+      kmip_free_text_string (ctx, value->build_level);
+      ctx->free_func (ctx->state, value->build_level);
+      value->build_level = NULL;
+    }
+  if (value->build_date != NULL)
+    {
+      kmip_free_text_string (ctx, value->build_date);
+      ctx->free_func (ctx->state, value->build_date);
+      value->build_date = NULL;
+    }
+  if (value->cluster_info != NULL)
+    {
+      kmip_free_text_string (ctx, value->cluster_info);
+      ctx->free_func (ctx->state, value->cluster_info);
+      value->cluster_info = NULL;
+    }
 
   if (value->alternative_failover_endpoints != NULL)
     {
       AltEndpoints *alt = value->alternative_failover_endpoints;
       if (alt->endpoint_list != NULL)
         {
-          LinkedListItem *item = kmip_linked_list_pop (alt->endpoint_list);
-          while (item != NULL)
+          LinkedListItem *curr = kmip_linked_list_pop (alt->endpoint_list);
+          while (curr != NULL)
             {
-              kmip_free_text_string (ctx, (TextString *)item->data);
-              ctx->free_func (ctx->state, item->data);
-              ctx->free_func (ctx->state, item);
-              item = kmip_linked_list_pop (alt->endpoint_list);
+              TextString *endpoint = (TextString *)curr->data;
+              if (endpoint != NULL)
+                {
+                  kmip_free_text_string (ctx, endpoint);
+                  ctx->free_func (ctx->state, endpoint);
+                }
+              curr->data = NULL;
+              ctx->free_func (ctx->state, curr);
+              curr = kmip_linked_list_pop (alt->endpoint_list);
             }
           ctx->free_func (ctx->state, alt->endpoint_list);
           alt->endpoint_list = NULL;
         }
-      ctx->free_func (ctx->state, value->alternative_failover_endpoints);
+      ctx->free_func (ctx->state, alt);
       value->alternative_failover_endpoints = NULL;
     }
 }


### PR DESCRIPTION
There are 2 commits.
1.  Fixed memory leaks discovered by Clang-20 ASAN running libkmip tests; Fixed 3 failing tests. These fixes do not touch the functionality used in kmippp.
2.   Add tests and ASAN conditional builds; Adds additional warning suppression for clang-20 and later

