### PR TITLE
chore(license): align kmipclient/kmipcore file headers with dual license

### DIFF
--- a/kmipclient/examples/example_activate.cpp
+++ b/kmipclient/examples/example_activate.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_create_aes.cpp
+++ b/kmipclient/examples/example_create_aes.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/Kmip.hpp"

--- a/kmipclient/examples/example_destroy.cpp
+++ b/kmipclient/examples/example_destroy.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get.cpp
+++ b/kmipclient/examples/example_get.cpp
@@ -1,19 +1,9 @@
 
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get_all_ids.cpp
+++ b/kmipclient/examples/example_get_all_ids.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get_attributes.cpp
+++ b/kmipclient/examples/example_get_attributes.cpp
@@ -1,19 +1,9 @@
 
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get_logger.cpp
+++ b/kmipclient/examples/example_get_logger.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get_name.cpp
+++ b/kmipclient/examples/example_get_name.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get_secret.cpp
+++ b/kmipclient/examples/example_get_secret.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_get_tls_verify.cpp
+++ b/kmipclient/examples/example_get_tls_verify.cpp
@@ -1,19 +1,9 @@
 
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_locate.cpp
+++ b/kmipclient/examples/example_locate.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_locate_by_group.cpp
+++ b/kmipclient/examples/example_locate_by_group.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_pool.cpp
+++ b/kmipclient/examples/example_pool.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 /**

--- a/kmipclient/examples/example_query_server_info.cpp
+++ b/kmipclient/examples/example_query_server_info.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 /**

--- a/kmipclient/examples/example_register_key.cpp
+++ b/kmipclient/examples/example_register_key.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 #include "kmipclient/KmipClient.hpp"
 #include "kmipclient/NetClientOpenSSL.hpp"

--- a/kmipclient/examples/example_register_secret.cpp
+++ b/kmipclient/examples/example_register_secret.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/Kmip.hpp"

--- a/kmipclient/examples/example_revoke.cpp
+++ b/kmipclient/examples/example_revoke.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/examples/example_supported_versions.cpp
+++ b/kmipclient/examples/example_supported_versions.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 /**

--- a/kmipclient/include/kmipclient/Key.hpp
+++ b/kmipclient/include/kmipclient/Key.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_KEY_HPP

--- a/kmipclient/include/kmipclient/KeyBase.hpp
+++ b/kmipclient/include/kmipclient/KeyBase.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_KEY_BASE_HPP

--- a/kmipclient/include/kmipclient/Kmip.hpp
+++ b/kmipclient/include/kmipclient/Kmip.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIP_HPP

--- a/kmipclient/include/kmipclient/KmipClient.hpp
+++ b/kmipclient/include/kmipclient/KmipClient.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 #ifndef KMIP_CLIENT_HPP
 #define KMIP_CLIENT_HPP

--- a/kmipclient/include/kmipclient/KmipClientPool.hpp
+++ b/kmipclient/include/kmipclient/KmipClientPool.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 #ifndef KMIPCLIENT_KMIP_CLIENT_POOL_HPP
 #define KMIPCLIENT_KMIP_CLIENT_POOL_HPP

--- a/kmipclient/include/kmipclient/KmipIOException.hpp
+++ b/kmipclient/include/kmipclient/KmipIOException.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPIOSEXCEPTION_HPP

--- a/kmipclient/include/kmipclient/NetClient.hpp
+++ b/kmipclient/include/kmipclient/NetClient.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIP_NET_CLIENT_HPP

--- a/kmipclient/include/kmipclient/NetClientOpenSSL.hpp
+++ b/kmipclient/include/kmipclient/NetClientOpenSSL.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPNETCLILENTOPENSSL_HPP

--- a/kmipclient/include/kmipclient/PEMReader.hpp
+++ b/kmipclient/include/kmipclient/PEMReader.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_PEM_READER_HPP

--- a/kmipclient/include/kmipclient/PrivateKey.hpp
+++ b/kmipclient/include/kmipclient/PrivateKey.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_PRIVATE_KEY_HPP

--- a/kmipclient/include/kmipclient/PublicKey.hpp
+++ b/kmipclient/include/kmipclient/PublicKey.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_PUBLIC_KEY_HPP

--- a/kmipclient/include/kmipclient/SymmetricKey.hpp
+++ b/kmipclient/include/kmipclient/SymmetricKey.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_SYMMETRIC_KEY_HPP

--- a/kmipclient/include/kmipclient/X509Certificate.hpp
+++ b/kmipclient/include/kmipclient/X509Certificate.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_X509_CERTIFICATE_HPP

--- a/kmipclient/include/kmipclient/kmipclient_version.hpp
+++ b/kmipclient/include/kmipclient/kmipclient_version.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCLIENT_VERSION_H

--- a/kmipclient/include/kmipclient/types.hpp
+++ b/kmipclient/include/kmipclient/types.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCLIENT_TYPES_HPP
 #define KMIPCLIENT_TYPES_HPP
 

--- a/kmipclient/src/IOUtils.cpp
+++ b/kmipclient/src/IOUtils.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "IOUtils.hpp"

--- a/kmipclient/src/IOUtils.hpp
+++ b/kmipclient/src/IOUtils.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef IOUTILS_HPP

--- a/kmipclient/src/Key.cpp
+++ b/kmipclient/src/Key.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/Key.hpp"

--- a/kmipclient/src/KmipClient.cpp
+++ b/kmipclient/src/KmipClient.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClient.hpp"

--- a/kmipclient/src/KmipClientPool.cpp
+++ b/kmipclient/src/KmipClientPool.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/KmipClientPool.hpp"

--- a/kmipclient/src/NetClientOpenSSL.cpp
+++ b/kmipclient/src/NetClientOpenSSL.cpp
@@ -1,19 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/NetClientOpenSSL.hpp"

--- a/kmipclient/src/PEMReader.cpp
+++ b/kmipclient/src/PEMReader.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/PEMReader.hpp"

--- a/kmipclient/src/PrivateKey.cpp
+++ b/kmipclient/src/PrivateKey.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/PrivateKey.hpp"

--- a/kmipclient/src/PublicKey.cpp
+++ b/kmipclient/src/PublicKey.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/PublicKey.hpp"

--- a/kmipclient/src/StringUtils.cpp
+++ b/kmipclient/src/StringUtils.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "StringUtils.hpp"

--- a/kmipclient/src/StringUtils.hpp
+++ b/kmipclient/src/StringUtils.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef STRINGUTILS_HPP

--- a/kmipclient/src/SymmetricKey.cpp
+++ b/kmipclient/src/SymmetricKey.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/SymmetricKey.hpp"

--- a/kmipclient/src/X509Certificate.cpp
+++ b/kmipclient/src/X509Certificate.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipclient/X509Certificate.hpp"

--- a/kmipclient/tests/IOUtilsTest.cpp
+++ b/kmipclient/tests/IOUtilsTest.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "../src/IOUtils.hpp"

--- a/kmipclient/tests/KmipClientIntegrationTest.cpp
+++ b/kmipclient/tests/KmipClientIntegrationTest.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "TestEnvUtils.hpp"

--- a/kmipclient/tests/KmipClientIntegrationTest_2_0.cpp
+++ b/kmipclient/tests/KmipClientIntegrationTest_2_0.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 /**

--- a/kmipclient/tests/KmipClientPoolIntegrationTest.cpp
+++ b/kmipclient/tests/KmipClientPoolIntegrationTest.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 /**

--- a/kmipclient/tests/TestEnvUtils.hpp
+++ b/kmipclient/tests/TestEnvUtils.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCLIENT_TESTS_TEST_ENV_UTILS_HPP
 #define KMIPCLIENT_TESTS_TEST_ENV_UTILS_HPP
 

--- a/kmipcore/include/kmipcore/attributes_parser.hpp
+++ b/kmipcore/include/kmipcore/attributes_parser.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_ATTRIBUTES_PARSER_HPP
 #define KMIPCORE_ATTRIBUTES_PARSER_HPP
 

--- a/kmipcore/include/kmipcore/key.hpp
+++ b/kmipcore/include/kmipcore/key.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCORE_KEY_HPP

--- a/kmipcore/include/kmipcore/key_parser.hpp
+++ b/kmipcore/include/kmipcore/key_parser.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCORE_KEY_PARSER_HPP

--- a/kmipcore/include/kmipcore/kmip_attribute_names.hpp
+++ b/kmipcore/include/kmipcore/kmip_attribute_names.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_ATTRIBUTE_NAMES_HPP
 #define KMIPCORE_KMIP_ATTRIBUTE_NAMES_HPP
 

--- a/kmipcore/include/kmipcore/kmip_attributes.hpp
+++ b/kmipcore/include/kmipcore/kmip_attributes.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCORE_KMIP_ATTRIBUTES_HPP

--- a/kmipcore/include/kmipcore/kmip_basics.hpp
+++ b/kmipcore/include/kmipcore/kmip_basics.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_BASICS_HPP
 #define KMIPCORE_KMIP_BASICS_HPP
 

--- a/kmipcore/include/kmipcore/kmip_errors.hpp
+++ b/kmipcore/include/kmipcore/kmip_errors.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_ERRORS_HPP
 #define KMIPCORE_KMIP_ERRORS_HPP
 

--- a/kmipcore/include/kmipcore/kmip_formatter.hpp
+++ b/kmipcore/include/kmipcore/kmip_formatter.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_FORMATTER_HPP
 #define KMIPCORE_KMIP_FORMATTER_HPP
 

--- a/kmipcore/include/kmipcore/kmip_logger.hpp
+++ b/kmipcore/include/kmipcore/kmip_logger.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_LOGGER_HPP
 #define KMIPCORE_KMIP_LOGGER_HPP
 

--- a/kmipcore/include/kmipcore/kmip_protocol.hpp
+++ b/kmipcore/include/kmipcore/kmip_protocol.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_PROTOCOL_HPP
 #define KMIPCORE_KMIP_PROTOCOL_HPP
 

--- a/kmipcore/include/kmipcore/kmip_requests.hpp
+++ b/kmipcore/include/kmipcore/kmip_requests.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_REQUESTS_HPP
 #define KMIPCORE_KMIP_REQUESTS_HPP
 

--- a/kmipcore/include/kmipcore/kmip_responses.hpp
+++ b/kmipcore/include/kmipcore/kmip_responses.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_KMIP_RESPONSES_HPP
 #define KMIPCORE_KMIP_RESPONSES_HPP
 

--- a/kmipcore/include/kmipcore/kmipcore_version.hpp
+++ b/kmipcore/include/kmipcore/kmipcore_version.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCORE_VERSION_HPP

--- a/kmipcore/include/kmipcore/managed_object.hpp
+++ b/kmipcore/include/kmipcore/managed_object.hpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #ifndef KMIPCORE_MANAGED_OBJECT_HPP

--- a/kmipcore/include/kmipcore/response_parser.hpp
+++ b/kmipcore/include/kmipcore/response_parser.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_RESPONSE_PARSER_HPP
 #define KMIPCORE_RESPONSE_PARSER_HPP
 

--- a/kmipcore/include/kmipcore/secret.hpp
+++ b/kmipcore/include/kmipcore/secret.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_SECRET_HPP
 #define KMIPCORE_SECRET_HPP
 

--- a/kmipcore/include/kmipcore/serialization_buffer.hpp
+++ b/kmipcore/include/kmipcore/serialization_buffer.hpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #ifndef KMIPCORE_SERIALIZATION_BUFFER_HPP
 #define KMIPCORE_SERIALIZATION_BUFFER_HPP
 

--- a/kmipcore/src/attributes_parser.cpp
+++ b/kmipcore/src/attributes_parser.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/attributes_parser.hpp"
 
 #include "kmipcore/kmip_attribute_names.hpp"

--- a/kmipcore/src/key_parser.cpp
+++ b/kmipcore/src/key_parser.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipcore/key_parser.hpp"

--- a/kmipcore/src/kmip_attributes.cpp
+++ b/kmipcore/src/kmip_attributes.cpp
@@ -1,18 +1,8 @@
 /* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; version 2 of
-   the License.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
  */
 
 #include "kmipcore/kmip_attributes.hpp"

--- a/kmipcore/src/kmip_basics.cpp
+++ b/kmipcore/src/kmip_basics.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_basics.hpp"
 
 #include "kmipcore/kmip_errors.hpp"

--- a/kmipcore/src/kmip_errors.cpp
+++ b/kmipcore/src/kmip_errors.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_errors.hpp"
 
 #include <cstdint>

--- a/kmipcore/src/kmip_formatter.cpp
+++ b/kmipcore/src/kmip_formatter.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_formatter.hpp"
 
 #include "kmipcore/kmip_basics.hpp"

--- a/kmipcore/src/kmip_payloads.cpp
+++ b/kmipcore/src/kmip_payloads.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_errors.hpp"
 #include "kmipcore/kmip_protocol.hpp"
 

--- a/kmipcore/src/kmip_protocol.cpp
+++ b/kmipcore/src/kmip_protocol.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_protocol.hpp"
 
 #include "kmipcore/kmip_errors.hpp"

--- a/kmipcore/src/kmip_requests.cpp
+++ b/kmipcore/src/kmip_requests.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_requests.hpp"
 
 #include "kmipcore/kmip_attribute_names.hpp"

--- a/kmipcore/src/kmip_responses.cpp
+++ b/kmipcore/src/kmip_responses.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/kmip_responses.hpp"
 
 #include "kmipcore/kmip_attribute_names.hpp"

--- a/kmipcore/src/response_parser.cpp
+++ b/kmipcore/src/response_parser.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/response_parser.hpp"
 
 #include "kmipcore/kmip_errors.hpp"

--- a/kmipcore/src/serialization_buffer.cpp
+++ b/kmipcore/src/serialization_buffer.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/serialization_buffer.hpp"
 
 #include "kmipcore/kmip_basics.hpp"

--- a/kmipcore/tests/test_core.cpp
+++ b/kmipcore/tests/test_core.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include <cassert>
 #include <iostream>
 #include <kmipcore/kmip_basics.hpp>

--- a/kmipcore/tests/test_parsers.cpp
+++ b/kmipcore/tests/test_parsers.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/attributes_parser.hpp"
 #include "kmipcore/key_parser.hpp"
 #include "kmipcore/kmip_attribute_names.hpp"

--- a/kmipcore/tests/test_serialization_buffer.cpp
+++ b/kmipcore/tests/test_serialization_buffer.cpp
@@ -1,3 +1,10 @@
+/* Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
+ *
+ * This file is dual licensed under the terms of the Apache 2.0 License and
+ * the BSD 3-Clause License. See the LICENSE file in the root of this
+ * repository for more information.
+ */
+
 #include "kmipcore/serialization_buffer.hpp"
 
 #include <cstring>


### PR DESCRIPTION
- Replace legacy GPL header blocks in kmipclient and kmipcore files with the project dual-license notice (Apache-2.0 OR BSD-3-Clause style text used in this repository).
- Preserve the Percona copyright line: Copyright (c) 2025 Percona LLC and/or its affiliates. All rights reserved.
- Add missing license headers to source/header/test files in kmipclient and kmipcore that previously had no top-of-file license block.
