### PR TITLE
Limit TTLV structure nesting depth in deserialization

### DIFF
--- a/kmipcore/include/kmipcore/kmip_enums.hpp
+++ b/kmipcore/include/kmipcore/kmip_enums.hpp
@@ -36,6 +36,17 @@ namespace kmipcore {
    * excessively large Maximum Response Size hint.
    */
   inline constexpr std::size_t KMIP_MAX_MESSAGE_HARD_LIMIT = 16 * 1024 * 1024;
+  /**
+   * Maximum nesting depth accepted when deserializing a TTLV structure tree.
+   *
+   * The wire format allows arbitrarily deep nesting, which would otherwise
+   * let a malicious peer drive unbounded recursion in the parser and exhaust
+   * the call stack. Real KMIP messages are only a handful of levels deep
+   * (Response Message -> Batch Item -> Payload -> Key Block -> Key Value ->
+   * Attributes -> Attribute -> Attribute Value), so this cap leaves ample
+   * headroom for valid traffic while bounding stack usage.
+   */
+  inline constexpr unsigned KMIP_MAX_STRUCTURE_DEPTH = 64;
   /** Suggested buffer size for human-readable error messages. */
   inline constexpr std::size_t KMIP_ERROR_MESSAGE_SIZE = 200;
 

--- a/kmipcore/src/kmip_basics.cpp
+++ b/kmipcore/src/kmip_basics.cpp
@@ -152,9 +152,13 @@ namespace kmipcore {
     }
   }
 
-  std::shared_ptr<Element> Element::deserialize(
-      std::span<const std::uint8_t> data, std::size_t &offset
+  static std::shared_ptr<Element> deserialize_impl(
+      std::span<const std::uint8_t> data, std::size_t &offset, unsigned depth
   ) {
+    if (depth > KMIP_MAX_STRUCTURE_DEPTH) {
+      throw KmipException("TTLV structure nesting depth exceeds limit");
+    }
+
     if (offset + 8 > data.size()) {
       throw KmipException("Buffer too short for header");
     }
@@ -210,7 +214,7 @@ namespace kmipcore {
       std::size_t current_struct_offset = 0;
       while (current_struct_offset < length) {
         std::size_t item_offset = offset;
-        auto child = deserialize(struct_view, item_offset);
+        auto child = deserialize_impl(struct_view, item_offset, depth + 1);
         std::get<Structure>(struct_elem->value).add(child);
         std::size_t consumed = item_offset - offset;
         current_struct_offset += consumed;
@@ -322,6 +326,12 @@ namespace kmipcore {
       offset += padded_length;
       return elem;
     }
+  }
+
+  std::shared_ptr<Element> Element::deserialize(
+      std::span<const std::uint8_t> data, std::size_t &offset
+  ) {
+    return deserialize_impl(data, offset, 0);
   }
 
   // Factory methods

--- a/kmipcore/tests/test_core.cpp
+++ b/kmipcore/tests/test_core.cpp
@@ -143,6 +143,58 @@ void test_non_zero_padding_is_rejected() {
   std::cout << "Non-zero padding validation test passed" << std::endl;
 }
 
+// Builds `depth` nested empty Structure elements on the wire, innermost
+// first, so the result is a single TTLV tree `depth` levels deep.
+std::vector<uint8_t> build_nested_structures(unsigned depth) {
+  std::vector<uint8_t> buf;
+  for (unsigned i = 0; i < depth; ++i) {
+    const auto len = static_cast<uint32_t>(buf.size());
+    std::vector<uint8_t> wrapper = {
+        0x42,
+        0x00,
+        0x01,
+        static_cast<uint8_t>(KMIP_TYPE_STRUCTURE),
+        static_cast<uint8_t>((len >> 24) & 0xFF),
+        static_cast<uint8_t>((len >> 16) & 0xFF),
+        static_cast<uint8_t>((len >> 8) & 0xFF),
+        static_cast<uint8_t>(len & 0xFF),
+    };
+    wrapper.insert(wrapper.end(), buf.begin(), buf.end());
+    buf = std::move(wrapper);
+  }
+  return buf;
+}
+
+void test_deeply_nested_structure_is_rejected() {
+  // A malicious server can send arbitrarily deep nesting; the parser must
+  // reject it before recursion exhausts the stack.
+  const auto data = build_nested_structures(1000);
+
+  size_t offset = 0;
+  bool threw = false;
+  try {
+    (void) Element::deserialize(data, offset);
+  } catch (const KmipException &) {
+    threw = true;
+  }
+  assert(threw);
+
+  std::cout << "Deeply nested structure rejection test passed" << std::endl;
+}
+
+void test_legitimate_nesting_is_accepted() {
+  // Real KMIP messages are only a handful of levels deep; the depth cap must
+  // leave comfortable headroom for valid traffic.
+  const auto data = build_nested_structures(30);
+
+  size_t offset = 0;
+  auto decoded = Element::deserialize(data, offset);
+  assert(offset == data.size());
+  assert(decoded->type == Type::KMIP_TYPE_STRUCTURE);
+
+  std::cout << "Legitimate nesting acceptance test passed" << std::endl;
+}
+
 void test_date_time_extended_requires_kmip_2_0_for_requests() {
   RequestBatchItem item;
   item.setOperation(KMIP_OP_GET);
@@ -871,6 +923,8 @@ int main() {
   test_date_time_extended_round_trip();
   test_date_time_extended_invalid_length();
   test_non_zero_padding_is_rejected();
+  test_deeply_nested_structure_is_rejected();
+  test_legitimate_nesting_is_accepted();
   test_date_time_extended_requires_kmip_2_0_for_requests();
   test_date_time_extended_requires_kmip_2_0_for_responses();
   test_request_message();


### PR DESCRIPTION
The TTLV wire format allows arbitrarily deep structure nesting, so a malicious peer could drive unbounded recursion in Element::deserialize and exhaust the call stack, crashing the client before authentication (security review finding F1).

Introduce KMIP_MAX_STRUCTURE_DEPTH (64) and reject any message that nests deeper. Real KMIP messages are only a handful of levels deep, so the cap leaves ample headroom for valid traffic.

Tests cover both rejection of a 1000-level-deep message and acceptance of legitimate nesting well above what real traffic produces.