### PR TITLE
Enable TLS verification by default in NetClientOpenSSL

### DIFF
--- a/kmipclient/include/kmipclient/NetClientOpenSSL.hpp
+++ b/kmipclient/include/kmipclient/NetClientOpenSSL.hpp
@@ -48,8 +48,10 @@ namespace kmipclient {
      * @param timeout_ms Timeout in milliseconds applied to TCP connect, TLS
      *        handshake, and each read/write operation.
      * @param tls_verification TLS peer/hostname verification settings.
-     *        Defaults to {false, false} (no peer verification, no hostname
-     *        verification). Call set_tls_verification() afterwards to change.
+     *        Defaults to {true, true} (peer and hostname verification both
+     *        enabled). Callers that need to disable verification (e.g. test or
+     *        development setups) must opt in explicitly, either by passing the
+     *        flags here or via set_tls_verification() afterwards.
      */
     NetClientOpenSSL(
         const std::string &host,
@@ -58,7 +60,7 @@ namespace kmipclient {
         const std::string &clientKeyFn,
         const std::string &serverCaCertFn,
         int timeout_ms = DEFAULT_TIMEOUT_MS,
-        TlsVerificationOptions tls_verification = {false, false}
+        TlsVerificationOptions tls_verification = {}
     );
     /** @brief Releases OpenSSL resources and closes any open connection. */
     ~NetClientOpenSSL() override;


### PR DESCRIPTION
The NetClientOpenSSL constructor defaulted tls_verification to {false, false}, silently disabling both TLS peer-certificate and hostname verification for any caller that did not pass the argument explicitly. This made man-in-the-middle attacks trivial by default, contradicting the safe {true, true} defaults of the underlying TlsVerificationOptions struct.

Default the argument to {} so it inherits the struct's secure defaults. Callers that need verification disabled (test or development setups) must now opt in explicitly via the constructor argument or set_tls_verification().