### PR TITLE
Adding a basic CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: ${{ matrix.compiler }} ${{ matrix.build }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        build: [Release, ASAN]
+    env:
+      CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
+      CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
+      # Must be set at BUILD time too: gtest test discovery runs post-build
+      # and filters the KMIP 2.0 suite out of the listing when unset.
+      KMIP_RUN_2_0_TESTS: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev ninja-build clang
+
+      - name: Cache Cosmian KMS package
+        uses: actions/cache@v4
+        with:
+          path: ~/cosmian-deb
+          key: cosmian-kms-5.21.0-${{ runner.arch }}
+
+      - name: Install Cosmian KMS
+        run: ci/install-cosmian.sh ~/cosmian-deb
+
+      - name: Configure
+        run: >
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=${{ matrix.build == 'ASAN' && 'Debug' || 'Release' }}
+          -DWITH_ASAN=${{ matrix.build == 'ASAN' && 'ON' || 'OFF' }}
+          -DBUILD_TESTS=ON
+          -DBUILD_KMIP_TESTS=ON
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Start Cosmian KMS
+        run: ci/start-cosmian.sh "${{ runner.temp }}/cosmian"
+
+      - name: Test
+        run: |
+          ctest --test-dir build --output-on-failure
+          log=build/Testing/Temporary/LastTest.log
+          if grep -F 'environment variables not configured' "$log"; then
+            echo "::error::KMIP test environment not configured; integration tests skipped"
+            exit 1
+          fi
+          if ! grep -q 'KmipClientIntegrationTest20\.' "$log"; then
+            echo "::error::KMIP 2.0 test suite did not run"
+            exit 1
+          fi
+          # 'listed below' filters gtest's count-summary line, which names no test
+          unexpected=$(grep -F '[  SKIPPED ]' "$log" \
+            | grep -v -e 'listed below' \
+                      -e 'NetClientOpenSSLCanRetryAfterFailedConnect' \
+                      -e 'KmipClientIntegrationTest\.LocatePageByGroupReportsLocatedItemsWhenServerProvidesIt' \
+            || true)
+          if [ -n "$unexpected" ]; then
+            echo "::error::unexpected skipped tests:"
+            echo "$unexpected"
+            exit 1
+          fi
+
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-${{ matrix.compiler }}-${{ matrix.build }}
+          path: |
+            ${{ runner.temp }}/cosmian/cosmian.log
+            ${{ runner.temp }}/cosmian/kms.toml
+            build/Testing/
+          if-no-files-found: ignore
+
+  format:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: pipx install clang-format==22.1.5
+
+      - name: Check formatting
+        run: ci/check-format.sh
+
+  docs:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Build docs
+        run: |
+          cmake -S . -B build-docs -DBUILD_DOCS=ON
+          cmake --build build-docs --target doc

--- a/ci/check-format.sh
+++ b/ci/check-format.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Checks formatting of the new C++ libraries (kmipcore, kmipclient).
+# Legacy code (libkmip, kmippp) is intentionally exempt.
+# Requires clang-format 22.1.5 on PATH (CI installs it via pipx; locally:
+# pip install clang-format==22.1.5).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ver="$(clang-format --version)"
+echo "$ver"
+if [[ "$ver" != *"version 22.1.5"* ]]; then
+  echo "error: clang-format 22.1.5 required (pipx install clang-format==22.1.5); found: $ver" >&2
+  exit 1
+fi
+
+if find kmipcore kmipclient \( -name '*.hpp' -o -name '*.cpp' \) -print0 \
+  | xargs -0r clang-format --dry-run --Werror; then
+  echo "formatting OK"
+else
+  echo "To fix: find kmipcore kmipclient \\( -name '*.hpp' -o -name '*.cpp' \\) -print0 | xargs -0 clang-format -i" >&2
+  exit 1
+fi

--- a/ci/install-cosmian.sh
+++ b/ci/install-cosmian.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Installs the pinned Cosmian KMS server on an Ubuntu CI runner.
+# Usage: ci/install-cosmian.sh [cache-dir]
+set -euo pipefail
+
+COSMIAN_VERSION=5.21.0
+CACHE_DIR="${1:-$HOME/cosmian-deb}"
+ARCH=$(dpkg --print-architecture)
+DEB="cosmian-kms-server-non-fips-static-openssl_${COSMIAN_VERSION}_${ARCH}.deb"
+
+mkdir -p "$CACHE_DIR"
+if [ ! -f "$CACHE_DIR/$DEB" ]; then
+  wget -q -O "$CACHE_DIR/$DEB.tmp" \
+    "https://package.cosmian.com/kms/${COSMIAN_VERSION}/deb/${ARCH}/non-fips/static/${DEB}"
+  mv "$CACHE_DIR/$DEB.tmp" "$CACHE_DIR/$DEB"
+fi
+
+sudo dpkg -i "$CACHE_DIR/$DEB"
+# .deb ships binary + bundled legacy.so as 0500 root:root; CI runner is non-root.
+sudo chmod 0755 /usr/sbin/cosmian_kms
+sudo chmod 0755 /usr/local/cosmian/lib/ossl-modules/legacy.so

--- a/ci/start-cosmian.sh
+++ b/ci/start-cosmian.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Starts a throwaway Cosmian KMS for the kmipclient integration tests.
+# Usage: ci/start-cosmian.sh <workdir>
+# Uses cosmian_kms from PATH, or $COSMIAN_KMS_BIN when set.
+# Appends KMIP_* test variables to $GITHUB_ENV when set (CI);
+# otherwise prints "export KMIP_*=..." lines for eval (local use).
+# The server keeps running; stop it with: kill "$(cat <workdir>/cosmian.pid)"
+set -euo pipefail
+
+WORKDIR="${1:?usage: start-cosmian.sh <workdir>}"
+BIN="${COSMIAN_KMS_BIN:-$(command -v cosmian_kms || true)}"
+if [ -z "$BIN" ]; then
+  echo "cosmian_kms not found on PATH; install it or set COSMIAN_KMS_BIN" >&2
+  exit 1
+fi
+mkdir -p "$WORKDIR"
+WORKDIR="$(cd "$WORKDIR" && pwd)"
+cd "$WORKDIR"
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout ca.key -out ca.pem -subj '/CN=libkmip-test-ca'
+openssl req -newkey rsa:2048 -nodes -keyout server.key -out server.csr \
+  -subj '/CN=127.0.0.1' -addext 'subjectAltName=IP:127.0.0.1'
+openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -days 1 -out server.pem -copy_extensions copy
+openssl pkcs12 -export -out server.p12 -inkey server.key -in server.pem \
+  -password pass:test
+openssl req -newkey rsa:2048 -nodes -keyout client.key -out client.csr \
+  -subj '/CN=libkmip-test-client'
+openssl x509 -req -in client.csr -CA ca.pem -CAkey ca.key -CAcreateserial \
+  -days 1 -out client.pem
+
+free_port() {
+  python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
+}
+KMIP_PORT="$(free_port)"
+HTTP_PORT="$(free_port)"
+
+cat > kms.toml <<TOML
+default_username = "admin"
+
+[db]
+database_type = "sqlite"
+sqlite_path   = "$WORKDIR/db"
+clear_database = true
+
+[tls]
+tls_p12_file         = "$WORKDIR/server.p12"
+tls_p12_password     = "test"
+clients_ca_cert_file = "$WORKDIR/ca.pem"
+
+[socket_server]
+socket_server_start    = true
+socket_server_port     = $KMIP_PORT
+socket_server_hostname = "127.0.0.1"
+
+[http]
+port     = $HTTP_PORT
+hostname = "127.0.0.1"
+
+[logging]
+rust_log = "info,cosmian_kms=info"
+TOML
+
+# Cosmian needs OPENSSL_MODULES; autodetect common locations when unset.
+if [ -z "${OPENSSL_MODULES:-}" ]; then
+  for d in /usr/local/cosmian/lib/ossl-modules /usr/lib64/ossl-modules \
+           /usr/lib/x86_64-linux-gnu/ossl-modules \
+           /usr/lib/aarch64-linux-gnu/ossl-modules; do
+    if [ -d "$d" ]; then
+      export OPENSSL_MODULES="$d"
+      break
+    fi
+  done
+fi
+
+"$BIN" -c "$WORKDIR/kms.toml" > "$WORKDIR/cosmian.log" 2>&1 &
+echo $! > "$WORKDIR/cosmian.pid"
+
+ready=""
+for _ in $(seq 1 75); do  # 15 s total, 200 ms steps
+  if curl -fsSk -m 1 "https://127.0.0.1:$HTTP_PORT/version" > /dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.2
+done
+if [ -z "$ready" ]; then
+  echo "cosmian_kms did not become ready within 15s" >&2
+  cat "$WORKDIR/cosmian.log" >&2
+  kill "$(cat "$WORKDIR/cosmian.pid")" 2> /dev/null || true
+  exit 1
+fi
+
+VARS="KMIP_ADDR=127.0.0.1
+KMIP_PORT=$KMIP_PORT
+KMIP_CLIENT_CA=$WORKDIR/client.pem
+KMIP_CLIENT_KEY=$WORKDIR/client.key
+KMIP_SERVER_CA=$WORKDIR/ca.pem
+KMIP_TIMEOUT_MS=5000
+KMIP_RUN_2_0_TESTS=1"
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "$VARS" >> "$GITHUB_ENV"
+else
+  echo "$VARS" | sed 's/^/export /'
+fi

--- a/kmipclient/examples/example_pool.cpp
+++ b/kmipclient/examples/example_pool.cpp
@@ -61,9 +61,8 @@ int main(int argc, char **argv) {
   const int num_threads = argc > 7 ? std::stoi(argv[7]) : 4;
   const int max_pool_size = argc > 8 ? std::stoi(argv[8]) : 2;
 
-  std::cout << "Launching " << num_threads
-            << " threads against a pool of max " << max_pool_size
-            << " connections\n";
+  std::cout << "Launching " << num_threads << " threads against a pool of max "
+            << max_pool_size << " connections\n";
 
   // ------------------------------------------------------------------
   // Build the pool.  No connections are created here yet.

--- a/kmipclient/include/kmipclient/Kmip.hpp
+++ b/kmipclient/include/kmipclient/Kmip.hpp
@@ -34,7 +34,8 @@ namespace kmipclient {
    *
    * Lifetime semantics:
    * - When stack-allocated: transport closes on scope exit (destructor).
-   * - When shared via std::shared_ptr: transport closes when last handle goes away.
+   * - When shared via std::shared_ptr: transport closes when last handle goes
+   * away.
    * - Can be moved to transfer ownership; copy is deleted for clarity.
    */
   class Kmip {
@@ -68,21 +69,24 @@ namespace kmipclient {
         NetClient::TlsVerificationOptions tls_verification = {false, false},
         bool close_on_destroy = true
     )
-      : m_net_client(std::make_shared<NetClientOpenSSL>(
-            host,
-            port,
-            clientCertificateFn,
-            clientKeyFn,
-            serverCaCertFn,
-            timeout_ms,
-            tls_verification
-        )),
+      : m_net_client(
+            std::make_shared<NetClientOpenSSL>(
+                host,
+                port,
+                clientCertificateFn,
+                clientKeyFn,
+                serverCaCertFn,
+                timeout_ms,
+                tls_verification
+            )
+        ),
         m_client(m_net_client, logger, version, close_on_destroy) {
       m_net_client->connect();
     };
 
     /**
-     * @brief Destroys the facade, closing the transport if close_on_destroy is true.
+     * @brief Destroys the facade, closing the transport if close_on_destroy is
+     * true.
      * @see set_close_on_destroy()
      */
     ~Kmip() = default;
@@ -91,7 +95,8 @@ namespace kmipclient {
     Kmip(Kmip &&) noexcept = default;
     Kmip &operator=(Kmip &&) noexcept = default;
 
-    // Non-copyable (for clarity: shared ownership should use std::shared_ptr<Kmip>)
+    // Non-copyable (for clarity: shared ownership should use
+    // std::shared_ptr<Kmip>)
     Kmip(const Kmip &) = delete;
     Kmip &operator=(const Kmip &) = delete;
 
@@ -115,7 +120,9 @@ namespace kmipclient {
     /**
      * @brief Returns const reference to the underlying transport.
      */
-    [[nodiscard]] const NetClientOpenSSL &transport() const { return *m_net_client; };
+    [[nodiscard]] const NetClientOpenSSL &transport() const {
+      return *m_net_client;
+    };
 
     /**
      * @brief Queries the close_on_destroy setting.

--- a/kmipclient/include/kmipclient/KmipClient.hpp
+++ b/kmipclient/include/kmipclient/KmipClient.hpp
@@ -327,7 +327,8 @@ namespace kmipclient {
     [[nodiscard]] std::vector<kmipcore::ProtocolVersion>
         op_discover_versions() const;
 
-    /** @brief Holds server information and capabilities returned by op_query(). */
+    /** @brief Holds server information and capabilities returned by op_query().
+     */
     struct QueryServerInfo {
       std::vector<kmipcore::operation>
           supported_operations;  ///< Operations supported by server
@@ -369,7 +370,8 @@ namespace kmipclient {
 
     /**
      * @brief Queries the close_on_destroy setting.
-     * @return true if the transport will be closed on destruction, false otherwise.
+     * @return true if the transport will be closed on destruction, false
+     * otherwise.
      */
     [[nodiscard]] bool close_on_destroy() const noexcept {
       return close_on_destroy_;

--- a/kmipclient/src/IOUtils.cpp
+++ b/kmipclient/src/IOUtils.cpp
@@ -80,10 +80,7 @@ namespace kmipclient {
         std::ostringstream oss;
         oss << "Can not send request. Bytes total: " << dlen
             << ", bytes sent: " << total_sent;
-        throw KmipIOException(
-            kmipcore::KMIP_IO_FAILURE,
-            oss.str()
-        );
+        throw KmipIOException(kmipcore::KMIP_IO_FAILURE, oss.str());
       }
       total_sent += sent;
     }
@@ -99,10 +96,7 @@ namespace kmipclient {
         std::ostringstream oss;
         oss << "Connection closed or error while reading. Expected " << n
             << ", got " << total_read;
-        throw KmipIOException(
-            kmipcore::KMIP_IO_FAILURE,
-            oss.str()
-        );
+        throw KmipIOException(kmipcore::KMIP_IO_FAILURE, oss.str());
       }
       total_read += received;
     }
@@ -120,10 +114,7 @@ namespace kmipclient {
       std::ostringstream oss;
       oss << "Message too long. Length: " << length
           << ", allowed: " << effective_limit;
-      throw KmipIOException(
-          kmipcore::KMIP_EXCEED_MAX_MESSAGE_SIZE,
-          oss.str()
-      );
+      throw KmipIOException(kmipcore::KMIP_EXCEED_MAX_MESSAGE_SIZE, oss.str());
     }
 
     std::vector<uint8_t> response(

--- a/kmipclient/src/KmipClient.cpp
+++ b/kmipclient/src/KmipClient.cpp
@@ -129,7 +129,9 @@ namespace kmipclient {
       kmipcore::ProtocolVersion version,
       bool close_on_destroy
   ) {
-    return std::make_shared<KmipClient>(net_client, logger, version, close_on_destroy);
+    return std::make_shared<KmipClient>(
+        net_client, logger, version, close_on_destroy
+    );
   }
 
   std::shared_ptr<KmipClient> KmipClient::create_shared(
@@ -138,7 +140,9 @@ namespace kmipclient {
       kmipcore::ProtocolVersion version,
       bool close_on_destroy
   ) {
-    return std::make_shared<KmipClient>(std::move(net_client), logger, version, close_on_destroy);
+    return std::make_shared<KmipClient>(
+        std::move(net_client), logger, version, close_on_destroy
+    );
   }
 
   KmipClient::~KmipClient() {
@@ -606,11 +610,7 @@ namespace kmipclient {
       const std::size_t page_size = std::min(remaining, MAX_ITEMS_IN_BATCH);
       std::optional<std::size_t> located_items;
       auto got = op_locate_page_by_group(
-          group,
-          o_type,
-          offset,
-          page_size,
-          &located_items
+          group, o_type, offset, page_size, &located_items
       );
 
       if (got.empty()) {
@@ -665,9 +665,10 @@ namespace kmipclient {
     );
 
     kmipcore::ResponseParser rf(response_bytes, request);
-    auto response = rf.getResponseByBatchItemId<kmipcore::LocateResponseBatchItem>(
-        batch_item_id
-    );
+    auto response =
+        rf.getResponseByBatchItemId<kmipcore::LocateResponseBatchItem>(
+            batch_item_id
+        );
 
     if (located_items != nullptr) {
       const auto total_items = response.getLocatePayload().getLocatedItems();
@@ -709,12 +710,8 @@ namespace kmipclient {
            batch < MAX_BATCHES_IN_SEARCH && result.size() < max_ids;
            ++batch) {
         std::optional<std::size_t> located_items;
-        auto page = op_all_page(
-            o_type,
-            offset,
-            probe_page_size,
-            &located_items
-        );
+        auto page =
+            op_all_page(o_type, offset, probe_page_size, &located_items);
         if (page.empty()) {
           break;
         }
@@ -731,7 +728,8 @@ namespace kmipclient {
           }
         }
 
-        if (located_items.has_value() && offset + probe_page_size >= *located_items) {
+        if (located_items.has_value() &&
+            offset + probe_page_size >= *located_items) {
           break;
         }
         if (!added_any && page.size() < probe_page_size) {

--- a/kmipclient/src/KmipClientPool.cpp
+++ b/kmipclient/src/KmipClientPool.cpp
@@ -180,12 +180,9 @@ namespace kmipclient {
     if (!slot_available) {
       std::ostringstream oss;
       oss << "KmipClientPool: no connection available after " << timeout.count()
-          << "ms (pool size: " << config_.max_connections
-          << ", all " << total_count_ << " connections in use)";
-      throw kmipcore::KmipException(
-          -1,
-          oss.str()
-      );
+          << "ms (pool size: " << config_.max_connections << ", all "
+          << total_count_ << " connections in use)";
+      throw kmipcore::KmipException(-1, oss.str());
     }
     return acquire_locked(std::move(lk));
   }

--- a/kmipclient/src/NetClientOpenSSL.cpp
+++ b/kmipclient/src/NetClientOpenSSL.cpp
@@ -336,7 +336,7 @@ namespace kmipclient {
           clientKeyFn,
           serverCaCertFn,
           timeout_ms
-        ) {
+      ) {
     m_tls_verification = tls_verification;
   }
 
@@ -362,8 +362,7 @@ namespace kmipclient {
     );
     if (!new_ctx) {
       throw KmipIOException(
-          kmipcore::KMIP_IO_FAILURE,
-          "SSL_CTX_new failed: " + getOpenSslError()
+          kmipcore::KMIP_IO_FAILURE, "SSL_CTX_new failed: " + getOpenSslError()
       );
     }
 
@@ -408,7 +407,9 @@ namespace kmipclient {
       );
     }
 
-    std::unique_ptr<BIO, BioDeleter> new_bio(BIO_new_ssl_connect(new_ctx.get()));
+    std::unique_ptr<BIO, BioDeleter> new_bio(
+        BIO_new_ssl_connect(new_ctx.get())
+    );
     if (!new_bio) {
       throw KmipIOException(
           kmipcore::KMIP_IO_FAILURE,
@@ -420,8 +421,7 @@ namespace kmipclient {
     BIO_get_ssl(new_bio.get(), &ssl);
     if (!ssl) {
       throw KmipIOException(
-          kmipcore::KMIP_IO_FAILURE,
-          "BIO_get_ssl failed: " + getOpenSslError()
+          kmipcore::KMIP_IO_FAILURE, "BIO_get_ssl failed: " + getOpenSslError()
       );
     }
 
@@ -434,8 +434,7 @@ namespace kmipclient {
     if (m_timeout_ms > 0) {
       if (BIO_set_nbio(new_bio.get(), 1) != 1) {
         throw KmipIOException(
-            kmipcore::KMIP_IO_FAILURE,
-            "BIO_set_nbio(1) failed before connect"
+            kmipcore::KMIP_IO_FAILURE, "BIO_set_nbio(1) failed before connect"
         );
       }
 
@@ -463,8 +462,7 @@ namespace kmipclient {
       restore_socket_blocking(new_bio.get());
       if (BIO_set_nbio(new_bio.get(), 0) != 1) {
         throw KmipIOException(
-            kmipcore::KMIP_IO_FAILURE,
-            "BIO_set_nbio(0) failed after connect"
+            kmipcore::KMIP_IO_FAILURE, "BIO_set_nbio(0) failed after connect"
         );
       }
     } else {
@@ -524,8 +522,7 @@ namespace kmipclient {
     const int ret = BIO_read(bio_.get(), data.data(), dlen);
     if (ret <= 0 && BIO_should_retry(bio_.get()) && is_timeout_errno()) {
       throw KmipIOException(
-          kmipcore::KMIP_IO_FAILURE,
-          timeoutMessage("receive", m_timeout_ms)
+          kmipcore::KMIP_IO_FAILURE, timeoutMessage("receive", m_timeout_ms)
       );
     }
     return ret;

--- a/kmipclient/tests/IOUtilsTest.cpp
+++ b/kmipclient/tests/IOUtilsTest.cpp
@@ -128,8 +128,7 @@ static_assert(
     "Kmip must be move-constructible"
 );
 static_assert(
-    std::is_move_assignable_v<kmipclient::Kmip>,
-    "Kmip must be move-assignable"
+    std::is_move_assignable_v<kmipclient::Kmip>, "Kmip must be move-assignable"
 );
 static_assert(
     !std::is_copy_constructible_v<kmipclient::Kmip>,
@@ -172,9 +171,8 @@ TEST(IOUtilsTest, SendFailsIfTransportStopsProgress) {
 TEST(IOUtilsTest, AcceptsResponsesLargerThanLegacy64KiBLimit) {
   FakeNetClient nc;
   const std::size_t payload_size = 128 * 1024;
-  nc.response_bytes = build_response_with_payload(
-      std::vector<uint8_t>(payload_size, 0xAB)
-  );
+  nc.response_bytes =
+      build_response_with_payload(std::vector<uint8_t>(payload_size, 0xAB));
 
   kmipclient::IOUtils io(nc);
   const std::vector<uint8_t> request{0x01};
@@ -204,7 +202,9 @@ TEST(IOUtilsTest, RejectsResponseThatExceedsCallerLimit) {
   }
 }
 
-TEST(IOUtilsTest, RejectsResponseThatExceedsHardLimitEvenIfCallerLimitIsHigher) {
+TEST(
+    IOUtilsTest, RejectsResponseThatExceedsHardLimitEvenIfCallerLimitIsHigher
+) {
   FakeNetClient nc;
   nc.response_bytes = build_response_with_payload(
       std::vector<uint8_t>(kmipcore::KMIP_MAX_MESSAGE_HARD_LIMIT + 1, 0x22)
@@ -216,9 +216,7 @@ TEST(IOUtilsTest, RejectsResponseThatExceedsHardLimitEvenIfCallerLimitIsHigher) 
 
   try {
     io.do_exchange(
-        request,
-        response,
-        kmipcore::KMIP_MAX_MESSAGE_HARD_LIMIT * 2
+        request, response, kmipcore::KMIP_MAX_MESSAGE_HARD_LIMIT * 2
     );
     FAIL() << "Expected do_exchange to enforce hard response limit";
   } catch (const kmipclient::KmipIOException &e) {

--- a/kmipclient/tests/KmipClientIntegrationTest.cpp
+++ b/kmipclient/tests/KmipClientIntegrationTest.cpp
@@ -242,8 +242,7 @@ TEST_F(KmipClientIntegrationTest, NetClientOpenSSLCanRetryAfterFailedConnect) {
     GTEST_SKIP() << "KMIP 1.4: environment does not produce a post-BIO "
                     "connect failure "
                     "for configured host '"
-                 << config.kmip_addr
-                 << "'; skipping retry regression test";
+                 << config.kmip_addr << "'; skipping retry regression test";
   }
 
   EXPECT_FALSE(net_client.is_connected());
@@ -274,14 +273,16 @@ TEST_F(KmipClientIntegrationTest, NetClientOpenSSLCanRetryAfterFailedConnect) {
   EXPECT_FALSE(net_client.is_connected());
 }
 
-TEST_F(KmipClientIntegrationTest, MoveConstructedKmipSupportsReadOnlyOperation) {
+TEST_F(
+    KmipClientIntegrationTest, MoveConstructedKmipSupportsReadOnlyOperation
+) {
   auto kmip = createKmipClient();
 
   Kmip moved_kmip(std::move(*kmip));
 
-  EXPECT_NO_THROW(
-      (void) moved_kmip.client().op_all(object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0)
-  );
+  EXPECT_NO_THROW((void) moved_kmip.client().op_all(
+      object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0
+  ));
 }
 
 TEST_F(KmipClientIntegrationTest, MoveConstructedKmipCanCreateAndGetKey) {
@@ -340,7 +341,9 @@ TEST_F(KmipClientIntegrationTest, LocateKeysByGroup) {
   }
 }
 
-TEST_F(KmipClientIntegrationTest, LocatePageByGroupSinglePageReturnsExpectedIds) {
+TEST_F(
+    KmipClientIntegrationTest, LocatePageByGroupSinglePageReturnsExpectedIds
+) {
   auto kmip = createKmipClient();
   std::string group_name =
       "test_locate_page_group_" + std::to_string(std::time(nullptr));
@@ -367,14 +370,21 @@ TEST_F(KmipClientIntegrationTest, LocatePageByGroupSinglePageReturnsExpectedIds)
 
     EXPECT_EQ(page.size(), 2u);
     for (const auto &id : page) {
-      EXPECT_NE(std::find(created_ids.begin(), created_ids.end(), id), created_ids.end());
+      EXPECT_NE(
+          std::find(created_ids.begin(), created_ids.end(), id),
+          created_ids.end()
+      );
     }
   } catch (kmipcore::KmipException &e) {
-    FAIL() << "LocatePageByGroupSinglePageReturnsExpectedIds failed: " << e.what();
+    FAIL() << "LocatePageByGroupSinglePageReturnsExpectedIds failed: "
+           << e.what();
   }
 }
 
-TEST_F(KmipClientIntegrationTest, LocatePageByGroupIteratesDeterministicallyWithOffset) {
+TEST_F(
+    KmipClientIntegrationTest,
+    LocatePageByGroupIteratesDeterministicallyWithOffset
+) {
   auto kmip = createKmipClient();
   std::string group_name =
       "test_locate_page_iter_" + std::to_string(std::time(nullptr));
@@ -399,11 +409,7 @@ TEST_F(KmipClientIntegrationTest, LocatePageByGroupIteratesDeterministicallyWith
         &first_located_items
     );
     auto first_page_repeat = kmip->client().op_locate_page_by_group(
-        group_name,
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        2,
-        nullptr
+        group_name, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 2, nullptr
     );
     ASSERT_FALSE(first_page.empty());
     EXPECT_EQ(first_page, first_page_repeat);
@@ -438,9 +444,7 @@ TEST_F(KmipClientIntegrationTest, LocatePageByGroupIteratesDeterministicallyWith
     }
 
     auto one_shot_ids = kmip->client().op_locate_by_group(
-        group_name,
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        created_ids.size()
+        group_name, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, created_ids.size()
     );
     if (offset_honored) {
       EXPECT_EQ(paged_ids, one_shot_ids);
@@ -449,23 +453,34 @@ TEST_F(KmipClientIntegrationTest, LocatePageByGroupIteratesDeterministicallyWith
       EXPECT_EQ(
           std::vector<std::string>(
               one_shot_ids.begin(),
-              one_shot_ids.begin() + static_cast<std::ptrdiff_t>(first_page.size())
+              one_shot_ids.begin() +
+                  static_cast<std::ptrdiff_t>(first_page.size())
           ),
           first_page
       );
     }
     for (const auto &id : paged_ids) {
-      EXPECT_NE(std::find(one_shot_ids.begin(), one_shot_ids.end(), id), one_shot_ids.end());
+      EXPECT_NE(
+          std::find(one_shot_ids.begin(), one_shot_ids.end(), id),
+          one_shot_ids.end()
+      );
     }
     for (const auto &id : created_ids) {
-      EXPECT_NE(std::find(one_shot_ids.begin(), one_shot_ids.end(), id), one_shot_ids.end());
+      EXPECT_NE(
+          std::find(one_shot_ids.begin(), one_shot_ids.end(), id),
+          one_shot_ids.end()
+      );
     }
   } catch (kmipcore::KmipException &e) {
-    FAIL() << "LocatePageByGroupIteratesDeterministicallyWithOffset failed: " << e.what();
+    FAIL() << "LocatePageByGroupIteratesDeterministicallyWithOffset failed: "
+           << e.what();
   }
 }
 
-TEST_F(KmipClientIntegrationTest, LocatePageByGroupReportsLocatedItemsWhenServerProvidesIt) {
+TEST_F(
+    KmipClientIntegrationTest,
+    LocatePageByGroupReportsLocatedItemsWhenServerProvidesIt
+) {
   auto kmip = createKmipClient();
   std::string group_name =
       "test_locate_page_total_" + std::to_string(std::time(nullptr));
@@ -509,22 +524,21 @@ TEST_F(KmipClientIntegrationTest, LocatePageByGroupReportsLocatedItemsWhenServer
   }
 }
 
-TEST_F(KmipClientIntegrationTest, LocatePageByGroupWithZeroPageSizeReturnsEmpty) {
+TEST_F(
+    KmipClientIntegrationTest, LocatePageByGroupWithZeroPageSizeReturnsEmpty
+) {
   auto kmip = createKmipClient();
 
   try {
     std::optional<std::size_t> located_items = 1;
     auto page = kmip->client().op_locate_page_by_group(
-        "",
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        0,
-        &located_items
+        "", object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 0, &located_items
     );
     EXPECT_TRUE(page.empty());
     EXPECT_FALSE(located_items.has_value());
   } catch (kmipcore::KmipException &e) {
-    FAIL() << "LocatePageByGroupWithZeroPageSizeReturnsEmpty failed: " << e.what();
+    FAIL() << "LocatePageByGroupWithZeroPageSizeReturnsEmpty failed: "
+           << e.what();
   }
 }
 
@@ -598,11 +612,7 @@ TEST_F(KmipClientIntegrationTest, GetAllIdsPageMatchesUngroupedLocatePage) {
 
     std::optional<std::size_t> locate_located_items;
     auto locate_page = kmip->client().op_locate_page_by_group(
-        "",
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        8,
-        &locate_located_items
+        "", object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 8, &locate_located_items
     );
 
     EXPECT_EQ(all_page, locate_page);
@@ -764,8 +774,7 @@ TEST_F(KmipClientIntegrationTest, RegisterThenActivateSymmetricKey) {
     EXPECT_EQ(attrs.object_state(), state::KMIP_STATE_ACTIVE)
         << "Key should be ACTIVE immediately after explicit activate";
   } catch (kmipcore::KmipException &e) {
-    FAIL() << "Get after RegisterThenActivateSymmetricKey failed: "
-           << e.what();
+    FAIL() << "Get after RegisterThenActivateSymmetricKey failed: " << e.what();
   }
 }
 
@@ -1100,9 +1109,8 @@ TEST_F(KmipClientIntegrationTest, CreateDuplicateNames) {
   auto kmip = createKmipClient();
   // Use a timestamp suffix so each test run gets a fresh name and does not
   // collide with a stale key left by a previous (possibly failed) run.
-  std::string name =
-      TESTING_NAME_PREFIX + "DuplicateNameTest_" +
-      std::to_string(std::time(nullptr));
+  std::string name = TESTING_NAME_PREFIX + "DuplicateNameTest_" +
+                     std::to_string(std::time(nullptr));
   std::string id1, id2;
   try {
     id1 = kmip->client().op_create_aes_key(name, TEST_GROUP);
@@ -1207,15 +1215,12 @@ TEST_F(KmipClientIntegrationTest, GetAllIdsIncludesCreatedKeys) {
 
     std::optional<std::size_t> located_items;
     (void) kmip->client().op_all_page(
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        1,
-        &located_items
+        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 1, &located_items
     );
 
     std::size_t max_ids = located_items.has_value()
-                              ? std::max(kDefaultSearchCap, *located_items)
-                              : kFallbackSearchCap;
+                            ? std::max(kDefaultSearchCap, *located_items)
+                            : kFallbackSearchCap;
     auto all_ids =
         kmip->client().op_all(object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, max_ids);
 

--- a/kmipclient/tests/KmipClientIntegrationTest_2_0.cpp
+++ b/kmipclient/tests/KmipClientIntegrationTest_2_0.cpp
@@ -619,8 +619,7 @@ TEST_F(KmipClientIntegrationTest20, RegisterThenActivateSecret) {
         << "Secret should be ACTIVE immediately after explicit activate";
     std::cout << "RegisterThenActivate secret id: " << id << std::endl;
   } catch (kmipcore::KmipException &e) {
-    FAIL() << "Get after RegisterThenActivateSecret (2.0) failed: "
-           << e.what();
+    FAIL() << "Get after RegisterThenActivateSecret (2.0) failed: " << e.what();
   }
 }
 
@@ -677,7 +676,9 @@ TEST_F(KmipClientIntegrationTest20, LocateKeysByGroup) {
   }
 }
 
-TEST_F(KmipClientIntegrationTest20, LocatePageByGroupSinglePageReturnsExpectedIds) {
+TEST_F(
+    KmipClientIntegrationTest20, LocatePageByGroupSinglePageReturnsExpectedIds
+) {
   auto kmip = createKmipClient();
   const std::string group =
       "test_2_0_locate_page_group_" + std::to_string(std::time(nullptr));
@@ -694,11 +695,7 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupSinglePageReturnsExpectedId
 
     std::optional<std::size_t> located_items;
     auto page = kmip->client().op_locate_page_by_group(
-        group,
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        2,
-        &located_items
+        group, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 2, &located_items
     );
     EXPECT_EQ(page.size(), 2u);
     for (const auto &id : page) {
@@ -710,7 +707,10 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupSinglePageReturnsExpectedId
   }
 }
 
-TEST_F(KmipClientIntegrationTest20, LocatePageByGroupIteratesDeterministicallyWithOffset) {
+TEST_F(
+    KmipClientIntegrationTest20,
+    LocatePageByGroupIteratesDeterministicallyWithOffset
+) {
   auto kmip = createKmipClient();
   const std::string group =
       "test_2_0_locate_page_iter_" + std::to_string(std::time(nullptr));
@@ -734,11 +734,7 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupIteratesDeterministicallyWi
         &first_located_items
     );
     auto first_page_repeat = kmip->client().op_locate_page_by_group(
-        group,
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        2,
-        nullptr
+        group, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 2, nullptr
     );
     ASSERT_FALSE(first_page.empty());
     EXPECT_EQ(first_page, first_page_repeat);
@@ -749,11 +745,7 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupIteratesDeterministicallyWi
     bool offset_honored = false;
     for (std::size_t i = 0; i < 8; ++i) {
       auto page = kmip->client().op_locate_page_by_group(
-          group,
-          object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-          offset,
-          2,
-          nullptr
+          group, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, offset, 2, nullptr
       );
       if (page.empty()) {
         break;
@@ -773,9 +765,7 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupIteratesDeterministicallyWi
     }
 
     auto one_shot = kmip->client().op_locate_by_group(
-        group,
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        created.size()
+        group, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, created.size()
     );
     if (offset_honored) {
       EXPECT_EQ(paged_ids, one_shot);
@@ -790,18 +780,26 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupIteratesDeterministicallyWi
       );
     }
     for (const auto &id : paged_ids) {
-      EXPECT_NE(std::find(one_shot.begin(), one_shot.end(), id), one_shot.end());
+      EXPECT_NE(
+          std::find(one_shot.begin(), one_shot.end(), id), one_shot.end()
+      );
     }
     for (const auto &id : created) {
-      EXPECT_NE(std::find(one_shot.begin(), one_shot.end(), id), one_shot.end());
+      EXPECT_NE(
+          std::find(one_shot.begin(), one_shot.end(), id), one_shot.end()
+      );
     }
   } catch (kmipcore::KmipException &e) {
-    FAIL() << "LocatePageByGroupIteratesDeterministicallyWithOffset (2.0) failed: "
-           << e.what();
+    FAIL()
+        << "LocatePageByGroupIteratesDeterministicallyWithOffset (2.0) failed: "
+        << e.what();
   }
 }
 
-TEST_F(KmipClientIntegrationTest20, LocatePageByGroupReportsLocatedItemsWhenServerProvidesIt) {
+TEST_F(
+    KmipClientIntegrationTest20,
+    LocatePageByGroupReportsLocatedItemsWhenServerProvidesIt
+) {
   auto kmip = createKmipClient();
   const std::string group =
       "test_2_0_locate_page_total_" + std::to_string(std::time(nullptr));
@@ -817,11 +815,7 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupReportsLocatedItemsWhenServ
 
     std::optional<std::size_t> located_items;
     auto page = kmip->client().op_locate_page_by_group(
-        group,
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        10,
-        &located_items
+        group, object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 10, &located_items
     );
 
     if (!located_items.has_value()) {
@@ -840,21 +834,18 @@ TEST_F(KmipClientIntegrationTest20, LocatePageByGroupReportsLocatedItemsWhenServ
   } catch (kmipcore::KmipException &e) {
     FAIL() << "LocatePageByGroupReportsLocatedItemsWhenServerProvidesIt "
            << "(KMIP " << protocol_version.getMajor() << "."
-           << protocol_version.getMinor() << ") failed: "
-           << e.what();
+           << protocol_version.getMinor() << ") failed: " << e.what();
   }
 }
 
-TEST_F(KmipClientIntegrationTest20, LocatePageByGroupWithZeroPageSizeReturnsEmpty) {
+TEST_F(
+    KmipClientIntegrationTest20, LocatePageByGroupWithZeroPageSizeReturnsEmpty
+) {
   auto kmip = createKmipClient();
   try {
     std::optional<std::size_t> located_items = 1;
     auto page = kmip->client().op_locate_page_by_group(
-        "",
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        0,
-        &located_items
+        "", object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 0, &located_items
     );
     EXPECT_TRUE(page.empty());
     EXPECT_FALSE(located_items.has_value());
@@ -1121,11 +1112,7 @@ TEST_F(KmipClientIntegrationTest20, GetAllIdsPageMatchesUngroupedLocatePage) {
 
     std::optional<std::size_t> locate_located_items;
     auto locate_page = kmip->client().op_locate_page_by_group(
-        "",
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        8,
-        &locate_located_items
+        "", object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 8, &locate_located_items
     );
 
     EXPECT_EQ(all_page, locate_page);
@@ -1155,16 +1142,14 @@ TEST_F(KmipClientIntegrationTest20, GetAllIdsIncludesCreatedKeys) {
 
     std::optional<std::size_t> located_items;
     (void) kmip->client().op_all_page(
-        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY,
-        0,
-        1,
-        &located_items
+        object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, 0, 1, &located_items
     );
 
     std::size_t max_ids = located_items.has_value()
-                              ? std::max(kDefaultSearchCap, *located_items)
-                              : kFallbackSearchCap;
-    auto all = kmip->client().op_all(object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, max_ids);
+                            ? std::max(kDefaultSearchCap, *located_items)
+                            : kFallbackSearchCap;
+    auto all =
+        kmip->client().op_all(object_type::KMIP_OBJTYPE_SYMMETRIC_KEY, max_ids);
 
     std::vector<std::string> missing_ids;
     for (const auto &cid : created) {

--- a/kmipclient/tests/KmipClientPoolIntegrationTest.cpp
+++ b/kmipclient/tests/KmipClientPoolIntegrationTest.cpp
@@ -457,8 +457,8 @@ TEST_F(KmipClientPoolIntegrationTest, ConcurrentOperationsWithReuse) {
 
           // Create a key
           auto key_id = conn->op_create_aes_key(
-              POOL_TEST_NAME_PREFIX + "stress_t" + std::to_string(t) +
-                  "_op" + std::to_string(op),
+              POOL_TEST_NAME_PREFIX + "stress_t" + std::to_string(t) + "_op" +
+                  std::to_string(op),
               TEST_GROUP
           );
           trackKeyForCleanup(key_id);

--- a/kmipcore/src/kmip_formatter.cpp
+++ b/kmipcore/src/kmip_formatter.cpp
@@ -400,9 +400,9 @@ namespace kmipcore {
     }
 
     [[nodiscard]] const char *revocation_reason_name(std::int32_t value) {
-      switch (
-          static_cast<revocation_reason_type>(static_cast<std::uint32_t>(value))
-      ) {
+      switch (static_cast<revocation_reason_type>(
+          static_cast<std::uint32_t>(value)
+      )) {
         case revocation_reason_type::KMIP_REVOKE_UNSPECIFIED:
           return "Unspecified";
         case revocation_reason_type::KMIP_REVOKE_KEY_COMPROMISE:

--- a/kmipcore/src/kmip_protocol.cpp
+++ b/kmipcore/src/kmip_protocol.cpp
@@ -283,8 +283,7 @@ namespace kmipcore {
   void RequestMessage::setMaxResponseSize(size_t size) {
     if (size > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
       throw KmipException(
-          "setMaxResponseSize: size_t value " +
-          std::to_string(size) +
+          "setMaxResponseSize: size_t value " + std::to_string(size) +
           " exceeds int32_t maximum (" +
           std::to_string(std::numeric_limits<int32_t>::max()) + ")"
       );

--- a/kmipcore/tests/test_core.cpp
+++ b/kmipcore/tests/test_core.cpp
@@ -843,8 +843,10 @@ void test_max_response_size_range_check() {
     req.setMaxResponseSize(2147483648UL);  // INT32_MAX + 1
     assert(false && "Should have thrown on overflow");
   } catch (const KmipException &e) {
-    assert(std::string(e.what()).find("exceeds int32_t maximum") !=
-           std::string::npos);
+    assert(
+        std::string(e.what()).find("exceeds int32_t maximum") !=
+        std::string::npos
+    );
   }
 
   // Invalid: very large size_t value
@@ -852,8 +854,10 @@ void test_max_response_size_range_check() {
     req.setMaxResponseSize(18446744073709551615UL);  // SIZE_MAX on 64-bit
     assert(false && "Should have thrown on overflow");
   } catch (const KmipException &e) {
-    assert(std::string(e.what()).find("exceeds int32_t maximum") !=
-           std::string::npos);
+    assert(
+        std::string(e.what()).find("exceeds int32_t maximum") !=
+        std::string::npos
+    );
   }
 
   std::cout << "MaxResponseSize range check test passed" << std::endl;


### PR DESCRIPTION
And fixing formatting issues as part of it, seems like clang-formating drifted as it wasn't enforced.