### PR TITLE
Strengthen handling of enums/bools

### DIFF
--- a/kmipcore/include/kmipcore/kmip_enums.hpp
+++ b/kmipcore/include/kmipcore/kmip_enums.hpp
@@ -974,6 +974,61 @@ namespace kmipcore {
   };
 
   // ---------------------------------------------------------------------------
+  // Validation of attacker-controlled enumeration values.
+  //
+  // Enumerations on the wire are unconstrained 4-byte values. Before a parsed
+  // value is cast into one of the scoped enums that drive key-handling
+  // decisions, callers validate it against the known KMIP value tables so a
+  // malicious server cannot inject out-of-range codes.
+  // ---------------------------------------------------------------------------
+
+  /** @brief Whether @p value is a defined Cryptographic Algorithm code. */
+  [[nodiscard]] inline bool
+      is_valid_cryptographic_algorithm(std::int32_t value) noexcept {
+    return value >= static_cast<std::int32_t>(
+                        cryptographic_algorithm::KMIP_CRYPTOALG_UNSET
+                    ) &&
+           value <= static_cast<std::int32_t>(
+                        cryptographic_algorithm::KMIP_CRYPTOALG_ED448
+                    );
+  }
+
+  /** @brief Whether @p value is a defined lifecycle State code. */
+  [[nodiscard]] inline bool is_valid_state(std::int32_t value) noexcept {
+    return value >= static_cast<std::int32_t>(state::KMIP_STATE_PRE_ACTIVE) &&
+           value <= static_cast<std::int32_t>(
+                        state::KMIP_STATE_DESTROYED_COMPROMISED
+                    );
+  }
+
+  /** @brief Whether @p value is a defined Secret Data Type code. */
+  [[nodiscard]] inline bool
+      is_valid_secret_data_type(std::int32_t value) noexcept {
+    const auto raw = static_cast<std::uint32_t>(value);
+    return raw == static_cast<std::uint32_t>(
+                      secret_data_type::KMIP_SECDATA_PASSWORD
+                  ) ||
+           raw == static_cast<std::uint32_t>(
+                      secret_data_type::KMIP_SECDATA_SEED
+                  ) ||
+           raw == static_cast<std::uint32_t>(
+                      secret_data_type::KMIP_SECDATA_EXTENSIONS
+                  );
+  }
+
+  /**
+   * @brief Whether @p value is a valid Cryptographic Usage Mask.
+   *
+   * The mask is a bit field; bits 0..23 (Sign .. FPE Decrypt) are the only
+   * defined flags. A value setting any other bit is rejected.
+   */
+  [[nodiscard]] inline bool
+      is_valid_cryptographic_usage_mask(std::int32_t value) noexcept {
+    constexpr std::uint32_t defined_bits = 0x00FFFFFFu;
+    return (static_cast<std::uint32_t>(value) & ~defined_bits) == 0;
+  }
+
+  // ---------------------------------------------------------------------------
   // Compatibility constants for legacy unqualified enumerator usage.
   // These preserve existing integer-based call sites while the codebase is
   // migrated to explicit scoped-enum references.

--- a/kmipcore/include/kmipcore/kmip_errors.hpp
+++ b/kmipcore/include/kmipcore/kmip_errors.hpp
@@ -37,6 +37,58 @@ namespace kmipcore {
     KmipException(int native_error_code, const std::string &msg);
   };
 
+  // ---------------------------------------------------------------------------
+  // Checked conversions of attacker-controlled enumeration values.
+  //
+  // These validate a raw wire value against the known KMIP value tables and
+  // throw KmipException on an out-of-range code, so the parsers never cast a
+  // malicious value into a scoped enum that steers key-handling decisions.
+  // ---------------------------------------------------------------------------
+
+  [[nodiscard]] inline cryptographic_algorithm
+      checked_cryptographic_algorithm(std::int32_t value) {
+    if (!is_valid_cryptographic_algorithm(value)) {
+      throw KmipException(
+          KMIP_ENUM_UNSUPPORTED,
+          "Unknown Cryptographic Algorithm enumeration value: " +
+              std::to_string(value)
+      );
+    }
+    return static_cast<cryptographic_algorithm>(value);
+  }
+
+  [[nodiscard]] inline state checked_state(std::int32_t value) {
+    if (!is_valid_state(value)) {
+      throw KmipException(
+          KMIP_ENUM_UNSUPPORTED,
+          "Unknown State enumeration value: " + std::to_string(value)
+      );
+    }
+    return static_cast<state>(value);
+  }
+
+  [[nodiscard]] inline secret_data_type
+      checked_secret_data_type(std::int32_t value) {
+    if (!is_valid_secret_data_type(value)) {
+      throw KmipException(
+          KMIP_ENUM_UNSUPPORTED,
+          "Unknown Secret Data Type enumeration value: " + std::to_string(value)
+      );
+    }
+    return static_cast<secret_data_type>(value);
+  }
+
+  [[nodiscard]] inline cryptographic_usage_mask
+      checked_cryptographic_usage_mask(std::int32_t value) {
+    if (!is_valid_cryptographic_usage_mask(value)) {
+      throw KmipException(
+          KMIP_ENUM_UNSUPPORTED,
+          "Invalid Cryptographic Usage Mask value: " + std::to_string(value)
+      );
+    }
+    return static_cast<cryptographic_usage_mask>(value);
+  }
+
 }  // namespace kmipcore
 
 #endif /* KMIPCORE_KMIP_ERRORS_HPP */

--- a/kmipcore/src/attributes_parser.cpp
+++ b/kmipcore/src/attributes_parser.cpp
@@ -8,6 +8,7 @@
 #include "kmipcore/attributes_parser.hpp"
 
 #include "kmipcore/kmip_attribute_names.hpp"
+#include "kmipcore/kmip_errors.hpp"
 
 #include <ctime>
 #include <iomanip>
@@ -126,20 +127,18 @@ namespace kmipcore {
 
       switch (elem->tag) {
         case tag::KMIP_TAG_CRYPTOGRAPHIC_ALGORITHM:
-          result.set_algorithm(
-              static_cast<cryptographic_algorithm>(elem->toEnum())
-          );
+          result.set_algorithm(checked_cryptographic_algorithm(elem->toEnum()));
           break;
         case tag::KMIP_TAG_CRYPTOGRAPHIC_LENGTH:
           result.set_crypto_length(elem->toInt());
           break;
         case tag::KMIP_TAG_CRYPTOGRAPHIC_USAGE_MASK:
           result.set_usage_mask(
-              static_cast<cryptographic_usage_mask>(elem->toInt())
+              checked_cryptographic_usage_mask(elem->toInt())
           );
           break;
         case tag::KMIP_TAG_STATE:
-          result.set_state(static_cast<state>(elem->toEnum()));
+          result.set_state(checked_state(elem->toEnum()));
           break;
         case tag::KMIP_TAG_NAME:
           // Name is a Structure: { Name Value (TextString), Name Type (Enum) }
@@ -252,7 +251,7 @@ namespace kmipcore {
         if (raw_name == "Cryptographic Algorithm") {
           if (attr_value_elem) {
             result.set_algorithm(
-                static_cast<cryptographic_algorithm>(attr_value_elem->toEnum())
+                checked_cryptographic_algorithm(attr_value_elem->toEnum())
             );
           }
           continue;
@@ -266,14 +265,14 @@ namespace kmipcore {
         if (raw_name == "Cryptographic Usage Mask") {
           if (attr_value_elem) {
             result.set_usage_mask(
-                static_cast<cryptographic_usage_mask>(attr_value_elem->toInt())
+                checked_cryptographic_usage_mask(attr_value_elem->toInt())
             );
           }
           continue;
         }
         if (raw_name == "State") {
           if (attr_value_elem) {
-            result.set_state(static_cast<state>(attr_value_elem->toEnum()));
+            result.set_state(checked_state(attr_value_elem->toEnum()));
           }
           continue;
         }

--- a/kmipcore/src/key_parser.cpp
+++ b/kmipcore/src/key_parser.cpp
@@ -58,7 +58,7 @@ namespace kmipcore {
       if (auto alg_elem =
               key_block->getChild(tag::KMIP_TAG_CRYPTOGRAPHIC_ALGORITHM)) {
         key_attrs.set_algorithm(
-            static_cast<cryptographic_algorithm>(alg_elem->toEnum())
+            checked_cryptographic_algorithm(alg_elem->toEnum())
         );
       }
       if (auto len_elem =
@@ -123,9 +123,7 @@ namespace kmipcore {
     secret.set_value(
         std::vector<unsigned char>(raw_bytes.begin(), raw_bytes.end())
     );
-    secret.set_secret_type(
-        static_cast<secret_data_type>(secret_type->toEnum())
-    );
+    secret.set_secret_type(checked_secret_data_type(secret_type->toEnum()));
     return secret;
   }
 

--- a/kmipcore/src/kmip_basics.cpp
+++ b/kmipcore/src/kmip_basics.cpp
@@ -266,7 +266,11 @@ namespace kmipcore {
             throw KmipException("Invalid length for Boolean");
           }
           std::uint64_t raw = read_be_u64(data, offset);
-          elem->value = Boolean{raw != 0};
+          // KMIP 1.4 §9.1.1.4.6: a Boolean must encode exactly 0 or 1.
+          if (raw != 0 && raw != 1) {
+            throw KmipException("Non-canonical Boolean TTLV value");
+          }
+          elem->value = Boolean{raw == 1};
           break;
         }
         case Type::KMIP_TYPE_ENUMERATION: {

--- a/kmipcore/tests/test_core.cpp
+++ b/kmipcore/tests/test_core.cpp
@@ -202,6 +202,53 @@ void test_legitimate_nesting_is_accepted() {
   std::cout << "Legitimate nesting acceptance test passed" << std::endl;
 }
 
+void test_boolean_non_canonical_rejected() {
+  // KMIP 1.4 §9.1.1.4.6: a Boolean must encode exactly 0 or 1. A malicious
+  // server sending any other 8-byte payload must be rejected, not collapsed
+  // to true.
+  auto make_boolean = [](std::uint64_t raw) {
+    std::vector<uint8_t> bytes = {
+        0x42,
+        0x00,
+        0x74,
+        static_cast<uint8_t>(KMIP_TYPE_BOOLEAN),
+        0x00,
+        0x00,
+        0x00,
+        0x08,
+    };
+    for (int shift = 56; shift >= 0; shift -= 8) {
+      bytes.push_back(static_cast<uint8_t>((raw >> shift) & 0xFF));
+    }
+    return bytes;
+  };
+
+  // Canonical values still decode correctly.
+  for (std::uint64_t raw : {std::uint64_t{0}, std::uint64_t{1}}) {
+    auto bytes = make_boolean(raw);
+    size_t offset = 0;
+    auto decoded = Element::deserialize(bytes, offset);
+    assert(decoded->type == kmipcore::Type::KMIP_TYPE_BOOLEAN);
+    assert(std::get<Boolean>(decoded->value).value == (raw == 1));
+  }
+
+  // Non-canonical values are rejected.
+  for (std::uint64_t raw :
+       {std::uint64_t{2}, std::uint64_t{0xFFFFFFFFFFFFFFFFULL}}) {
+    auto bytes = make_boolean(raw);
+    size_t offset = 0;
+    bool threw = false;
+    try {
+      (void) Element::deserialize(bytes, offset);
+    } catch (const KmipException &) {
+      threw = true;
+    }
+    assert(threw);
+  }
+
+  std::cout << "Boolean non-canonical rejection test passed" << std::endl;
+}
+
 void test_date_time_extended_requires_kmip_2_0_for_requests() {
   RequestBatchItem item;
   item.setOperation(KMIP_OP_GET);
@@ -969,6 +1016,7 @@ int main() {
   test_non_zero_padding_is_rejected();
   test_deeply_nested_structure_is_rejected();
   test_legitimate_nesting_is_accepted();
+  test_boolean_non_canonical_rejected();
   test_date_time_extended_requires_kmip_2_0_for_requests();
   test_date_time_extended_requires_kmip_2_0_for_responses();
   test_request_message();

--- a/kmipcore/tests/test_parsers.cpp
+++ b/kmipcore/tests/test_parsers.cpp
@@ -433,6 +433,58 @@ void test_key_parser_secret_binary() {
   std::cout << "KeyParser Secret Binary test passed" << std::endl;
 }
 
+void test_key_parser_rejects_out_of_range_secret_type() {
+  // An attacker-controlled Secret Data Type enumeration that is not one of the
+  // known values must be rejected rather than cast into the scoped enum.
+  auto payload = Element::createStructure(tag::KMIP_TAG_RESPONSE_PAYLOAD);
+  payload->asStructure()->add(
+      Element::createTextString(tag::KMIP_TAG_UNIQUE_IDENTIFIER, "secret-id")
+  );
+  payload->asStructure()->add(
+      Element::createEnumeration(
+          tag::KMIP_TAG_OBJECT_TYPE, KMIP_OBJTYPE_SECRET_DATA
+      )
+  );
+
+  auto secret_data = Element::createStructure(tag::KMIP_TAG_SECRET_DATA);
+  secret_data->asStructure()->add(
+      Element::createEnumeration(tag::KMIP_TAG_SECRET_DATA_TYPE, 0x7F)
+  );
+
+  auto key_block = Element::createStructure(tag::KMIP_TAG_KEY_BLOCK);
+  key_block->asStructure()->add(
+      Element::createEnumeration(
+          tag::KMIP_TAG_KEY_FORMAT_TYPE, KMIP_KEYFORMAT_OPAQUE
+      )
+  );
+  auto key_value = Element::createStructure(tag::KMIP_TAG_KEY_VALUE);
+  key_value->asStructure()->add(
+      Element::createByteString(
+          tag::KMIP_TAG_KEY_MATERIAL, std::vector<uint8_t>{'p', 'w'}
+      )
+  );
+  key_block->asStructure()->add(key_value);
+  secret_data->asStructure()->add(key_block);
+  payload->asStructure()->add(secret_data);
+
+  ResponseBatchItem item;
+  item.setOperation(KMIP_OP_GET);
+  item.setResultStatus(KMIP_STATUS_SUCCESS);
+  item.setResponsePayload(payload);
+
+  GetResponseBatchItem get_resp = GetResponseBatchItem::fromBatchItem(item);
+  bool threw = false;
+  try {
+    (void) KeyParser::parseGetSecretResponse(get_resp);
+  } catch (const KmipException &) {
+    threw = true;
+  }
+  assert(threw);
+
+  std::cout << "KeyParser out-of-range secret type rejection test passed"
+            << std::endl;
+}
+
 void test_register_secret_request_structure() {
   const std::vector<unsigned char> secret = {'a', 'b', 0x00, 'c'};
   RegisterSecretRequest req(
@@ -625,6 +677,54 @@ void test_attributes_parser_v2_typed() {
   assert(result.get_int("Tag(0x420003)").value() == 3600);
 
   std::cout << "AttributesParser KMIP 2.0 typed attributes test passed"
+            << std::endl;
+}
+
+void test_attributes_parser_rejects_out_of_range_enums() {
+  // A malicious server can send any 4-byte Enumeration. Security-relevant
+  // attributes (algorithm, state, usage mask) must be validated against the
+  // known KMIP value tables before being cast into the scoped enums that steer
+  // key-handling decisions.
+  auto expect_throws = [](const std::shared_ptr<Element> &attr) {
+    std::vector<std::shared_ptr<Element>> attrs{attr};
+    bool threw = false;
+    try {
+      (void) AttributesParser::parse(attrs);
+    } catch (const KmipException &) {
+      threw = true;
+    }
+    assert(threw);
+  };
+
+  // Out-of-range cryptographic algorithm (0x39 is one past Ed448 = 0x38).
+  expect_throws(
+      Element::createEnumeration(tag::KMIP_TAG_CRYPTOGRAPHIC_ALGORITHM, 0x39)
+  );
+  // Out-of-range lifecycle state (valid range 0x01..0x06).
+  expect_throws(Element::createEnumeration(tag::KMIP_TAG_STATE, 0x07));
+  // Usage mask with bits outside the defined 0..23 flag range.
+  expect_throws(
+      Element::createInteger(
+          tag::KMIP_TAG_CRYPTOGRAPHIC_USAGE_MASK,
+          static_cast<int32_t>(0x01000000)
+      )
+  );
+
+  // Same validation on the KMIP 1.x Attribute name/value wrapper path.
+  {
+    auto attr = Element::createStructure(tag::KMIP_TAG_ATTRIBUTE);
+    attr->asStructure()->add(
+        Element::createTextString(
+            tag::KMIP_TAG_ATTRIBUTE_NAME, "Cryptographic Algorithm"
+        )
+    );
+    attr->asStructure()->add(
+        Element::createEnumeration(tag::KMIP_TAG_ATTRIBUTE_VALUE, 0x39)
+    );
+    expect_throws(attr);
+  }
+
+  std::cout << "AttributesParser out-of-range enum rejection test passed"
             << std::endl;
 }
 
@@ -908,10 +1008,12 @@ int main() {
   test_response_parser_operation_hint_when_operation_absent();
   test_key_parser_symmetric();
   test_key_parser_secret_binary();
+  test_key_parser_rejects_out_of_range_secret_type();
   test_register_secret_request_structure();
   test_attributes_parser();
   test_attributes_parser_extended();
   test_attributes_parser_v2_typed();
+  test_attributes_parser_rejects_out_of_range_enums();
   test_attributes_parser_legacy_wrapper_preserves_generic_types();
   test_get_attributes_request_encodes_per_protocol_version();
   test_get_attribute_list_response_supports_v2_attribute_reference();


### PR DESCRIPTION
Previously both boolean and enum handling simply accepted any value sent by the server. After this change, we verify that we receive values properly allowed by the KMIP specification - a valid value for the specific enum, or only 0 and 1 in case of booleans.