### PR TITLE
PG-2513: Make client connected flag atomic

### DIFF
--- a/kmipclient/include/kmipclient/NetClient.hpp
+++ b/kmipclient/include/kmipclient/NetClient.hpp
@@ -8,6 +8,7 @@
 #ifndef KMIP_NET_CLIENT_HPP
 #define KMIP_NET_CLIENT_HPP
 
+#include <atomic>
 #include <cstdint>
 #include <span>
 #include <string>
@@ -99,7 +100,7 @@ namespace kmipclient {
      * @brief Checks whether a connection is currently established.
      * @return true when connected, false otherwise.
      */
-    [[nodiscard]] bool is_connected() const { return m_isConnected; }
+    [[nodiscard]] bool is_connected() const noexcept { return m_isConnected; }
     /**
      * @brief Sends bytes over the established connection.
      * @param data Source buffer.
@@ -122,7 +123,7 @@ namespace kmipclient {
     std::string m_serverCaCertificateFn;
     int m_timeout_ms;
     TlsVerificationOptions m_tls_verification{};
-    bool m_isConnected = false;
+    std::atomic<bool> m_isConnected{false};
   };
 }  // namespace kmipclient
 #endif  // KMIP_NET_CLIENT_HPP

--- a/kmipclient/src/NetClientOpenSSL.cpp
+++ b/kmipclient/src/NetClientOpenSSL.cpp
@@ -331,13 +331,13 @@ namespace kmipclient {
 
   NetClientOpenSSL::~NetClientOpenSSL() {
     // Avoid calling virtual methods from destructor.
+    m_isConnected = false;
     if (bio_) {
       bio_.reset();
     }
     if (ctx_) {
       ctx_.reset();
     }
-    m_isConnected = false;
   }
 
   bool NetClientOpenSSL::connect() {
@@ -477,6 +477,7 @@ namespace kmipclient {
   }
 
   void NetClientOpenSSL::close() {
+    m_isConnected = false;
     if (bio_) {
       // BIO_free_all is called by unique_ptr reset
       bio_.reset();
@@ -484,7 +485,6 @@ namespace kmipclient {
     if (ctx_) {
       ctx_.reset();
     }
-    m_isConnected = false;
   }
 
   int NetClientOpenSSL::send(std::span<const std::uint8_t> data) {

--- a/kmipclient/src/NetClientOpenSSL.cpp
+++ b/kmipclient/src/NetClientOpenSSL.cpp
@@ -330,14 +330,7 @@ namespace kmipclient {
   }
 
   NetClientOpenSSL::~NetClientOpenSSL() {
-    // Avoid calling virtual methods from destructor.
-    m_isConnected = false;
-    if (bio_) {
-      bio_.reset();
-    }
-    if (ctx_) {
-      ctx_.reset();
-    }
+    close();
   }
 
   bool NetClientOpenSSL::connect() {
@@ -478,13 +471,8 @@ namespace kmipclient {
 
   void NetClientOpenSSL::close() {
     m_isConnected = false;
-    if (bio_) {
-      // BIO_free_all is called by unique_ptr reset
-      bio_.reset();
-    }
-    if (ctx_) {
-      ctx_.reset();
-    }
+    bio_.reset();
+    ctx_.reset();
   }
 
   int NetClientOpenSSL::send(std::span<const std::uint8_t> data) {


### PR DESCRIPTION
This fixes a possible race as it can be used by multiple threads, e.g.

Also clean up the order of pointer cleanup and connected flag unset. The client code is still thread unsafe even with this change, but it at least makes the connected handling more consistent. 