### PR TITLE
Remove the UNSET key type

### DIFF
--- a/kmipclient/src/Key.cpp
+++ b/kmipclient/src/Key.cpp
@@ -36,7 +36,6 @@ namespace kmipclient {
         return std::make_unique<X509Certificate>(
             core_key.value(), core_key.attributes()
         );
-      case KeyType::UNSET:
       default:
         throw kmipcore::KmipException(
             "Unsupported key type in core->client conversion"

--- a/kmipcore/include/kmipcore/key.hpp
+++ b/kmipcore/include/kmipcore/key.hpp
@@ -14,13 +14,7 @@
 namespace kmipcore {
 
   /** @brief Key object families represented by @ref Key. */
-  enum class KeyType {
-    UNSET,
-    SYMMETRIC_KEY,
-    PUBLIC_KEY,
-    PRIVATE_KEY,
-    CERTIFICATE
-  };
+  enum class KeyType { SYMMETRIC_KEY, PUBLIC_KEY, PRIVATE_KEY, CERTIFICATE };
 
   /**
    * Minimal crypto key representation as KMIP spec sees it.
@@ -46,9 +40,6 @@ namespace kmipcore {
     )
       : ManagedObject(value, std::move(attrs)), key_type(k_type) {}
 
-    /** @brief Constructs an empty key object. */
-    Key() = default;
-
     Key(const Key &) = default;
     Key &operator=(const Key &) = default;
     Key(Key &&) noexcept = default;
@@ -61,7 +52,7 @@ namespace kmipcore {
     [[nodiscard]] size_t size() const noexcept { return value_.size(); }
 
   private:
-    KeyType key_type = KeyType::UNSET;
+    KeyType key_type;
   };
 
 }  // namespace kmipcore

--- a/kmipcore/src/kmip_requests.cpp
+++ b/kmipcore/src/kmip_requests.cpp
@@ -233,7 +233,6 @@ namespace kmipcore {
               KMIP_NOT_IMPLEMENTED,
               "Certificate registration is not yet supported"
           );
-        case KeyType::UNSET:
         default:
           throw KmipException(
               KMIP_INVALID_FIELD, "Unsupported key type for Register"
@@ -250,7 +249,6 @@ namespace kmipcore {
           return KMIP_OBJTYPE_PUBLIC_KEY;
         case KeyType::CERTIFICATE:
           return KMIP_OBJTYPE_CERTIFICATE;
-        case KeyType::UNSET:
         default:
           throw KmipException(
               KMIP_INVALID_FIELD, "Unsupported key type for Register"


### PR DESCRIPTION
The `UNSET` key type is not part of the protocol so there is no reason to have it. While at it also remove the constructor for an "empty" key object. That is not something we are using either, and a key without value or type does not make much sense to support.