### PR TITLE
Only ignore directories named build if they are in the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-build
+/build


### PR DESCRIPTION
I do not think there is any good reason for having a `build` directory in a subdirectory, so limit the scope to ignore only exactly what we want to ignore.