### PR TITLE
PG-2553, PG-2552: Fix an error on recent GCC versions and add an ARM CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,15 @@ permissions:
 
 jobs:
   build-test:
-    name: ${{ matrix.compiler }} ${{ matrix.build }}
-    runs-on: ubuntu-24.04
+    name: ${{ matrix.compiler }} ${{ matrix.build }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         compiler: [gcc, clang]
         build: [Release, ASAN]
+        arch: [x64, arm64]
     env:
       CC: ${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}
       CXX: ${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
@@ -87,7 +88,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failure-${{ matrix.compiler }}-${{ matrix.build }}
+          name: failure-${{ matrix.compiler }}-${{ matrix.build }}-${{ matrix.arch }}
           path: |
             ${{ runner.temp }}/cosmian/cosmian.log
             ${{ runner.temp }}/cosmian/kms.toml

--- a/kmipclient/include/kmipclient/NetClient.hpp
+++ b/kmipclient/include/kmipclient/NetClient.hpp
@@ -64,9 +64,9 @@ namespace kmipclient {
     virtual ~NetClient() = default;
     // no copy, no move
     NetClient(const NetClient &) = delete;
-    virtual NetClient &operator=(const NetClient &) = delete;
+    NetClient &operator=(const NetClient &) = delete;
     NetClient(NetClient &&) = delete;
-    virtual NetClient &operator=(NetClient &&) = delete;
+    NetClient &operator=(NetClient &&) = delete;
     /**
      * @brief Establishes network/TLS connection to the KMIP server.
      *        Must honor @ref m_timeout_ms for connect + handshake phases.


### PR DESCRIPTION
As we detected it in the pg_tde ARM CI runner which uses a more recent gcc version.